### PR TITLE
Added tests and refactored code (Part 3)

### DIFF
--- a/src/blueprints/ember-addon/__addonLocation__/unpublished-development-types/index.d.ts
+++ b/src/blueprints/ember-addon/__addonLocation__/unpublished-development-types/index.d.ts
@@ -1,7 +1,7 @@
 // Add any types here that you need for local development only.
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
-
-<% if (options.packages.addon.hasGlint) { %>import '@glint/environment-ember-loose';
+<% if (options.packages.addon.hasGlint) { %>
+import '@glint/environment-ember-loose';
 
 declare module '@glint/environment-ember-loose/registry' {
   // Remove this once entries have been added! 👇
@@ -10,4 +10,5 @@ declare module '@glint/environment-ember-loose/registry' {
     // Add any registry entries from other addons here that your addon itself uses (in non-strict mode templates)
     // See https://typed-ember.gitbook.io/glint/using-glint/ember/using-addons
   }
-}<% } %>
+}
+<% } %>

--- a/src/blueprints/ember-addon/package.json
+++ b/src/blueprints/ember-addon/package.json
@@ -16,7 +16,7 @@
     "prepare": "npm run build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "npm start --workspace <%= options.packages.addon.name %>",
-    "start:tests": "npm start --workspace <%= options.packages.testApp.name %>",
+    "start:test-app": "npm start --workspace <%= options.packages.testApp.name %>",
     "test": "npm run test --workspaces --if-present"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "prepare": "pnpm build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "pnpm --filter <%= options.packages.addon.name %> start",
-    "start:test": "pnpm --filter <%= options.packages.testApp.name %> start",
+    "start:test-app": "pnpm --filter <%= options.packages.testApp.name %> start",
     "test": "pnpm --filter '*' test"
   },
   "devDependencies": {
@@ -66,7 +66,7 @@
     "prepare": "yarn build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace <%= options.packages.addon.name %> run start",
-    "start:test": "yarn workspace <%= options.packages.testApp.name %> run start",
+    "start:test-app": "yarn workspace <%= options.packages.testApp.name %> run start",
     "test": "yarn workspaces run test"
   },
   "devDependencies": {

--- a/src/migration/ember-addon/steps/move-project-root-files.js
+++ b/src/migration/ember-addon/steps/move-project-root-files.js
@@ -33,6 +33,7 @@ function moveToAddonAndTestApp(options) {
 
   const files = packages.addon.hasTypeScript
     ? [
+        '.eslintignore',
         '.eslintrc.js',
         '.gitignore',
         '.prettierignore',
@@ -43,6 +44,7 @@ function moveToAddonAndTestApp(options) {
         'tsconfig.json',
       ]
     : [
+        '.eslintignore',
         '.eslintrc.js',
         '.gitignore',
         '.prettierignore',
@@ -83,7 +85,6 @@ function moveToTestApp(options) {
 
   const files = [
     '.ember-cli',
-    '.eslintignore',
     '.watchmanconfig',
     'ember-cli-build.js',
     'testem.js',

--- a/tests/fixtures/ember-container-query-customizations/output/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace ember-container-query run start",
-    "start:test": "yarn workspace demo-app-for-ember-container-query run start",
+    "start:test-app": "yarn workspace demo-app-for-ember-container-query run start",
     "test": "yarn workspaces run test"
   },
   "devDependencies": {

--- a/tests/fixtures/ember-container-query-javascript/output/package.json
+++ b/tests/fixtures/ember-container-query-javascript/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace ember-container-query run start",
-    "start:test": "yarn workspace test-app run start",
+    "start:test-app": "yarn workspace test-app run start",
     "test": "yarn workspaces run test"
   },
   "devDependencies": {

--- a/tests/fixtures/ember-container-query-typescript/output/package.json
+++ b/tests/fixtures/ember-container-query-typescript/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace ember-container-query run start",
-    "start:test": "yarn workspace test-app run start",
+    "start:test-app": "yarn workspace test-app run start",
     "test": "yarn workspaces run test"
   },
   "devDependencies": {

--- a/tests/fixtures/new-v1-addon-customizations/output/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace new-v1-addon run start",
-    "start:test": "yarn workspace demo-app-for-new-v1-addon run start",
+    "start:test-app": "yarn workspace demo-app-for-new-v1-addon run start",
     "test": "yarn workspaces run test"
   },
   "devDependencies": {

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/unpublished-development-types/index.d.ts
@@ -1,4 +1,2 @@
 // Add any types here that you need for local development only.
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
-
-

--- a/tests/fixtures/new-v1-addon-javascript/output/package.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace new-v1-addon run start",
-    "start:test": "yarn workspace test-app run start",
+    "start:test-app": "yarn workspace test-app run start",
     "test": "yarn workspaces run test"
   },
   "devDependencies": {

--- a/tests/fixtures/new-v1-addon-npm/output/package.json
+++ b/tests/fixtures/new-v1-addon-npm/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "npm run build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "npm start --workspace new-v1-addon",
-    "start:tests": "npm start --workspace test-app",
+    "start:test-app": "npm start --workspace test-app",
     "test": "npm run test --workspaces --if-present"
   },
   "devDependencies": {

--- a/tests/fixtures/new-v1-addon-pnpm/output/package.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "pnpm build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "pnpm --filter new-v1-addon start",
-    "start:test": "pnpm --filter test-app start",
+    "start:test-app": "pnpm --filter test-app start",
     "test": "pnpm --filter '*' test"
   },
   "devDependencies": {

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/unpublished-development-types/index.d.ts
@@ -1,4 +1,2 @@
 // Add any types here that you need for local development only.
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
-
-

--- a/tests/fixtures/new-v1-addon-typescript/output/package.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace new-v1-addon run start",
-    "start:test": "yarn workspace test-app run start",
+    "start:test-app": "yarn workspace test-app run start",
     "test": "yarn workspaces run test"
   },
   "devDependencies": {

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/.gitignore
@@ -1,0 +1,32 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/.env*
+/.pnp*
+/.sass-cache
+/.eslintcache
+/connect.lock
+/coverage/
+/libpeerconnection.log
+/npm-debug.log*
+/testem.log
+/yarn-error.log
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try
+
+# broccoli-debug
+/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/.prettierignore
@@ -1,0 +1,25 @@
+# unconventional js
+/blueprints/*/files/
+/vendor/
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/coverage/
+!.*
+.*/
+.eslintcache
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/.prettierrc.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/.prettierrc.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  singleQuote: true,
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/demo-app/ember-cli-build.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/demo-app/ember-cli-build.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // Add options here
+    autoImport: {
+      watchDependencies: ['ember-container-query'],
+    },
+  });
+
+  const { maybeEmbroider } = require('@embroider/test-setup');
+
+  return maybeEmbroider(app);
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/demo-app/types/global.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/demo-app/types/global.d.ts
@@ -1,0 +1,7 @@
+// Types for compiled templates
+declare module 'demo-app-for-ember-container-query/templates/*' {
+  import { TemplateFactory } from 'ember-cli-htmlbars';
+
+  const tmpl: TemplateFactory;
+  export default tmpl;
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/package.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ember-container-query",
+  "version": "3.2.0",
+  "private": true,
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "workspaces": [
+    "ember-container-query",
+    "demo-app-for-ember-container-query"
+  ],
+  "scripts": {
+    "build": "yarn workspace ember-container-query run build",
+    "lint": "yarn workspaces run lint",
+    "lint:fix": "yarn workspaces run lint:fix",
+    "prepare": "yarn build",
+    "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+    "start:addon": "yarn workspace ember-container-query run start",
+    "start:test": "yarn workspace demo-app-for-ember-container-query run start",
+    "test": "yarn workspaces run test"
+  },
+  "devDependencies": {
+    "concurrently": "^7.6.0",
+    "prettier": "^2.8.3"
+  }
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/package.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace ember-container-query run start",
-    "start:test": "yarn workspace demo-app-for-ember-container-query run start",
+    "start:test-app": "yarn workspace demo-app-for-ember-container-query run start",
     "test": "yarn workspaces run test"
   },
   "devDependencies": {

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/.eslintignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/.eslintignore
@@ -1,0 +1,8 @@
+# unconventional js
+/blueprints/*/files/
+
+# compiled output
+/dist/
+
+# misc
+/coverage/

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/addon-main.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/addon-main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { addonV1Shim } = require('@embroider/addon-shim');
+
+module.exports = addonV1Shim(__dirname);

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/babel.config.json
@@ -1,0 +1,8 @@
+{
+  "presets": [["@babel/preset-typescript"]],
+  "plugins": [
+    "@embroider/addon-dev/template-colocation-plugin",
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-class-properties"
+  ]
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/rollup.config.mjs
@@ -1,0 +1,55 @@
+import typescript from 'rollup-plugin-ts';
+import copy from 'rollup-plugin-copy';
+import { Addon } from '@embroider/addon-dev/rollup';
+
+const addon = new Addon({
+  srcDir: 'src',
+  destDir: 'dist',
+});
+
+export default {
+  // This provides defaults that work well alongside `publicEntrypoints` below.
+  // You can augment this if you need to.
+  output: addon.output(),
+
+  plugins: [
+    // These are the modules that users should be able to import from your
+    // addon. Anything not listed here may get optimized away.
+    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+
+    // These are the modules that should get reexported into the traditional
+    // "app" tree. Things in here should also be in publicEntrypoints above, but
+    // not everything in publicEntrypoints necessarily needs to go here.
+    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+
+    // Follow the V2 Addon rules about dependencies. Your code can import from
+    // `dependencies` and `peerDependencies` as well as standard Ember-provided
+    // package names.
+    addon.dependencies(),
+
+    // compile TypeScript to latest JavaScript, including Babel transpilation
+    typescript({
+      transpiler: 'babel',
+      browserslist: false,
+      transpileOnly: false,
+    }),
+
+    // Ensure that standalone .hbs files are properly integrated as Javascript.
+    addon.hbs(),
+
+    // addons are allowed to contain imports of .css files, which we want rollup
+    // to leave alone and keep in the published output.
+    addon.keepAssets(['**/*.css']),
+
+    // Remove leftover build artifacts when starting a new build.
+    addon.clean(),
+
+    // Copy Readme and License into published package
+    copy({
+      targets: [
+        { src: '../README.md', dest: '.' },
+        { src: '../LICENSE.md', dest: '.' },
+      ],
+    }),
+  ],
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/unpublished-development-types/index.d.ts
@@ -1,4 +1,2 @@
 // Add any types here that you need for local development only.
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
-
-

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/unpublished-development-types/index.d.ts
@@ -1,0 +1,4 @@
+// Add any types here that you need for local development only.
+// These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
+
+

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/.gitignore
@@ -1,0 +1,32 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/.env*
+/.pnp*
+/.sass-cache
+/.eslintcache
+/connect.lock
+/coverage/
+/libpeerconnection.log
+/npm-debug.log*
+/testem.log
+/yarn-error.log
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try
+
+# broccoli-debug
+/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/.prettierignore
@@ -1,0 +1,25 @@
+# unconventional js
+/blueprints/*/files/
+/vendor/
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/coverage/
+!.*
+.*/
+.eslintcache
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/.prettierrc.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/.prettierrc.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  singleQuote: true,
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/.eslintignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/.eslintignore
@@ -1,0 +1,8 @@
+# unconventional js
+/blueprints/*/files/
+
+# compiled output
+/dist/
+
+# misc
+/coverage/

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/addon-main.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/addon-main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { addonV1Shim } = require('@embroider/addon-shim');
+
+module.exports = addonV1Shim(__dirname);

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/babel.config.json
@@ -1,0 +1,8 @@
+{
+  "presets": [["@babel/preset-typescript"]],
+  "plugins": [
+    "@embroider/addon-dev/template-colocation-plugin",
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-class-properties"
+  ]
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/rollup.config.mjs
@@ -1,0 +1,55 @@
+import typescript from 'rollup-plugin-ts';
+import copy from 'rollup-plugin-copy';
+import { Addon } from '@embroider/addon-dev/rollup';
+
+const addon = new Addon({
+  srcDir: 'src',
+  destDir: 'dist',
+});
+
+export default {
+  // This provides defaults that work well alongside `publicEntrypoints` below.
+  // You can augment this if you need to.
+  output: addon.output(),
+
+  plugins: [
+    // These are the modules that users should be able to import from your
+    // addon. Anything not listed here may get optimized away.
+    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+
+    // These are the modules that should get reexported into the traditional
+    // "app" tree. Things in here should also be in publicEntrypoints above, but
+    // not everything in publicEntrypoints necessarily needs to go here.
+    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+
+    // Follow the V2 Addon rules about dependencies. Your code can import from
+    // `dependencies` and `peerDependencies` as well as standard Ember-provided
+    // package names.
+    addon.dependencies(),
+
+    // compile TypeScript to latest JavaScript, including Babel transpilation
+    typescript({
+      transpiler: 'babel',
+      browserslist: false,
+      transpileOnly: false,
+    }),
+
+    // Ensure that standalone .hbs files are properly integrated as Javascript.
+    addon.hbs(),
+
+    // addons are allowed to contain imports of .css files, which we want rollup
+    // to leave alone and keep in the published output.
+    addon.keepAssets(['**/*.css']),
+
+    // Remove leftover build artifacts when starting a new build.
+    addon.clean(),
+
+    // Copy Readme and License into published package
+    copy({
+      targets: [
+        { src: '../README.md', dest: '.' },
+        { src: '../LICENSE.md', dest: '.' },
+      ],
+    }),
+  ],
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/unpublished-development-types/index.d.ts
@@ -1,0 +1,13 @@
+// Add any types here that you need for local development only.
+// These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
+
+import '@glint/environment-ember-loose';
+
+declare module '@glint/environment-ember-loose/registry' {
+  // Remove this once entries have been added! 👇
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export default interface Registry {
+    // Add any registry entries from other addons here that your addon itself uses (in non-strict mode templates)
+    // See https://typed-ember.gitbook.io/glint/using-glint/ember/using-addons
+  }
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/package.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ember-container-query",
+  "version": "3.2.0",
+  "private": true,
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "workspaces": [
+    "ember-container-query",
+    "test-app"
+  ],
+  "scripts": {
+    "build": "yarn workspace ember-container-query run build",
+    "lint": "yarn workspaces run lint",
+    "lint:fix": "yarn workspaces run lint:fix",
+    "prepare": "yarn build",
+    "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+    "start:addon": "yarn workspace ember-container-query run start",
+    "start:test-app": "yarn workspace test-app run start",
+    "test": "yarn workspaces run test"
+  },
+  "devDependencies": {
+    "concurrently": "^7.6.0",
+    "prettier": "^2.8.3"
+  }
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/test-app/ember-cli-build.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/test-app/ember-cli-build.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // Add options here
+    autoImport: {
+      watchDependencies: ['ember-container-query'],
+    },
+  });
+
+  const { maybeEmbroider } = require('@embroider/test-setup');
+
+  return maybeEmbroider(app);
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/test-app/types/global.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/test-app/types/global.d.ts
@@ -1,0 +1,7 @@
+// Types for compiled templates
+declare module 'test-app/templates/*' {
+  import { TemplateFactory } from 'ember-cli-htmlbars';
+
+  const tmpl: TemplateFactory;
+  export default tmpl;
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/.gitignore
@@ -1,0 +1,32 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/.env*
+/.pnp*
+/.sass-cache
+/.eslintcache
+/connect.lock
+/coverage/
+/libpeerconnection.log
+/npm-debug.log*
+/testem.log
+/yarn-error.log
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try
+
+# broccoli-debug
+/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/.prettierignore
@@ -1,0 +1,25 @@
+# unconventional js
+/blueprints/*/files/
+/vendor/
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/coverage/
+!.*
+.*/
+.eslintcache
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/.prettierrc.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/.prettierrc.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  singleQuote: true,
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/ember-container-query/.eslintignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/ember-container-query/.eslintignore
@@ -1,0 +1,8 @@
+# unconventional js
+/blueprints/*/files/
+
+# compiled output
+/dist/
+
+# misc
+/coverage/

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/ember-container-query/addon-main.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/ember-container-query/addon-main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { addonV1Shim } = require('@embroider/addon-shim');
+
+module.exports = addonV1Shim(__dirname);

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/ember-container-query/babel.config.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "@embroider/addon-dev/template-colocation-plugin",
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-class-properties"
+  ]
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/ember-container-query/rollup.config.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/ember-container-query/rollup.config.js
@@ -1,0 +1,58 @@
+import babel from '@rollup/plugin-babel';
+import copy from 'rollup-plugin-copy';
+import { Addon } from '@embroider/addon-dev/rollup';
+
+const addon = new Addon({
+  srcDir: 'src',
+  destDir: 'dist',
+});
+
+export default {
+  // This provides defaults that work well alongside `publicEntrypoints` below.
+  // You can augment this if you need to.
+  output: addon.output(),
+
+  plugins: [
+    // These are the modules that users should be able to import from your
+    // addon. Anything not listed here may get optimized away.
+    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+
+    // These are the modules that should get reexported into the traditional
+    // "app" tree. Things in here should also be in publicEntrypoints above, but
+    // not everything in publicEntrypoints necessarily needs to go here.
+    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+
+    // Follow the V2 Addon rules about dependencies. Your code can import from
+    // `dependencies` and `peerDependencies` as well as standard Ember-provided
+    // package names.
+    addon.dependencies(),
+
+    // This babel config should *not* apply presets or compile away ES modules.
+    // It exists only to provide development niceties for you, like automatic
+    // template colocation.
+    //
+    // By default, this will load the actual babel config from the file
+    // babel.config.json.
+    babel({
+      babelHelpers: 'bundled',
+    }),
+
+    // Ensure that standalone .hbs files are properly integrated as Javascript.
+    addon.hbs(),
+
+    // addons are allowed to contain imports of .css files, which we want rollup
+    // to leave alone and keep in the published output.
+    addon.keepAssets(['**/*.css']),
+
+    // Remove leftover build artifacts when starting a new build.
+    addon.clean(),
+
+    // Copy Readme and License into published package
+    copy({
+      targets: [
+        { src: '../README.md', dest: '.' },
+        { src: '../LICENSE.md', dest: '.' },
+      ],
+    }),
+  ],
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/package.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace ember-container-query run start",
-    "start:test": "yarn workspace test-app run start",
+    "start:test-app": "yarn workspace test-app run start",
     "test": "yarn workspaces run test"
   },
   "devDependencies": {

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/package.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ember-container-query",
+  "version": "3.2.0",
+  "private": true,
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "workspaces": [
+    "ember-container-query",
+    "test-app"
+  ],
+  "scripts": {
+    "build": "yarn workspace ember-container-query run build",
+    "lint": "yarn workspaces run lint",
+    "lint:fix": "yarn workspaces run lint:fix",
+    "prepare": "yarn build",
+    "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+    "start:addon": "yarn workspace ember-container-query run start",
+    "start:test": "yarn workspace test-app run start",
+    "test": "yarn workspaces run test"
+  },
+  "devDependencies": {
+    "concurrently": "^7.6.0",
+    "prettier": "^2.8.3"
+  }
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/test-app/ember-cli-build.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/test-app/ember-cli-build.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // Add options here
+    autoImport: {
+      watchDependencies: ['ember-container-query'],
+    },
+  });
+
+  const { maybeEmbroider } = require('@embroider/test-setup');
+
+  return maybeEmbroider(app);
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/.gitignore
@@ -1,0 +1,32 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/.env*
+/.pnp*
+/.sass-cache
+/.eslintcache
+/connect.lock
+/coverage/
+/libpeerconnection.log
+/npm-debug.log*
+/testem.log
+/yarn-error.log
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try
+
+# broccoli-debug
+/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/.prettierignore
@@ -1,0 +1,25 @@
+# unconventional js
+/blueprints/*/files/
+/vendor/
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/coverage/
+!.*
+.*/
+.eslintcache
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/.prettierrc.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/.prettierrc.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  singleQuote: true,
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/.eslintignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/.eslintignore
@@ -1,0 +1,8 @@
+# unconventional js
+/blueprints/*/files/
+
+# compiled output
+/dist/
+
+# misc
+/coverage/

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/addon-main.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/addon-main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { addonV1Shim } = require('@embroider/addon-shim');
+
+module.exports = addonV1Shim(__dirname);

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/babel.config.json
@@ -1,0 +1,8 @@
+{
+  "presets": [["@babel/preset-typescript"]],
+  "plugins": [
+    "@embroider/addon-dev/template-colocation-plugin",
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-class-properties"
+  ]
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/rollup.config.mjs
@@ -1,0 +1,55 @@
+import typescript from 'rollup-plugin-ts';
+import copy from 'rollup-plugin-copy';
+import { Addon } from '@embroider/addon-dev/rollup';
+
+const addon = new Addon({
+  srcDir: 'src',
+  destDir: 'dist',
+});
+
+export default {
+  // This provides defaults that work well alongside `publicEntrypoints` below.
+  // You can augment this if you need to.
+  output: addon.output(),
+
+  plugins: [
+    // These are the modules that users should be able to import from your
+    // addon. Anything not listed here may get optimized away.
+    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+
+    // These are the modules that should get reexported into the traditional
+    // "app" tree. Things in here should also be in publicEntrypoints above, but
+    // not everything in publicEntrypoints necessarily needs to go here.
+    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+
+    // Follow the V2 Addon rules about dependencies. Your code can import from
+    // `dependencies` and `peerDependencies` as well as standard Ember-provided
+    // package names.
+    addon.dependencies(),
+
+    // compile TypeScript to latest JavaScript, including Babel transpilation
+    typescript({
+      transpiler: 'babel',
+      browserslist: false,
+      transpileOnly: false,
+    }),
+
+    // Ensure that standalone .hbs files are properly integrated as Javascript.
+    addon.hbs(),
+
+    // addons are allowed to contain imports of .css files, which we want rollup
+    // to leave alone and keep in the published output.
+    addon.keepAssets(['**/*.css']),
+
+    // Remove leftover build artifacts when starting a new build.
+    addon.clean(),
+
+    // Copy Readme and License into published package
+    copy({
+      targets: [
+        { src: '../README.md', dest: '.' },
+        { src: '../LICENSE.md', dest: '.' },
+      ],
+    }),
+  ],
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/unpublished-development-types/index.d.ts
@@ -1,0 +1,2 @@
+// Add any types here that you need for local development only.
+// These will *not* be published as part of your addon, so be careful that your published code does not rely on them!

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/package.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ember-container-query",
+  "version": "3.2.0",
+  "private": true,
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "workspaces": [
+    "ember-container-query",
+    "test-app"
+  ],
+  "scripts": {
+    "build": "npm run build --workspace ember-container-query",
+    "lint": "npm run lint --workspaces --if-present",
+    "lint:fix": "npm run lint:fix --workspaces --if-present",
+    "prepare": "npm run build",
+    "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+    "start:addon": "npm start --workspace ember-container-query",
+    "start:test-app": "npm start --workspace test-app",
+    "test": "npm run test --workspaces --if-present"
+  },
+  "devDependencies": {
+    "concurrently": "^7.6.0",
+    "prettier": "^2.8.3"
+  }
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/test-app/ember-cli-build.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/test-app/ember-cli-build.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // Add options here
+    autoImport: {
+      watchDependencies: ['ember-container-query'],
+    },
+  });
+
+  const { maybeEmbroider } = require('@embroider/test-setup');
+
+  return maybeEmbroider(app);
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/test-app/types/global.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/test-app/types/global.d.ts
@@ -1,0 +1,7 @@
+// Types for compiled templates
+declare module 'test-app/templates/*' {
+  import { TemplateFactory } from 'ember-cli-htmlbars';
+
+  const tmpl: TemplateFactory;
+  export default tmpl;
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/.gitignore
@@ -1,0 +1,32 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/.env*
+/.pnp*
+/.sass-cache
+/.eslintcache
+/connect.lock
+/coverage/
+/libpeerconnection.log
+/npm-debug.log*
+/testem.log
+/yarn-error.log
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try
+
+# broccoli-debug
+/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/.prettierignore
@@ -1,0 +1,25 @@
+# unconventional js
+/blueprints/*/files/
+/vendor/
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/coverage/
+!.*
+.*/
+.eslintcache
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/.prettierrc.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/.prettierrc.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  singleQuote: true,
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/.eslintignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/.eslintignore
@@ -1,0 +1,8 @@
+# unconventional js
+/blueprints/*/files/
+
+# compiled output
+/dist/
+
+# misc
+/coverage/

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/addon-main.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/addon-main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { addonV1Shim } = require('@embroider/addon-shim');
+
+module.exports = addonV1Shim(__dirname);

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/babel.config.json
@@ -1,0 +1,8 @@
+{
+  "presets": [["@babel/preset-typescript"]],
+  "plugins": [
+    "@embroider/addon-dev/template-colocation-plugin",
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-class-properties"
+  ]
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/rollup.config.mjs
@@ -1,0 +1,55 @@
+import typescript from 'rollup-plugin-ts';
+import copy from 'rollup-plugin-copy';
+import { Addon } from '@embroider/addon-dev/rollup';
+
+const addon = new Addon({
+  srcDir: 'src',
+  destDir: 'dist',
+});
+
+export default {
+  // This provides defaults that work well alongside `publicEntrypoints` below.
+  // You can augment this if you need to.
+  output: addon.output(),
+
+  plugins: [
+    // These are the modules that users should be able to import from your
+    // addon. Anything not listed here may get optimized away.
+    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+
+    // These are the modules that should get reexported into the traditional
+    // "app" tree. Things in here should also be in publicEntrypoints above, but
+    // not everything in publicEntrypoints necessarily needs to go here.
+    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+
+    // Follow the V2 Addon rules about dependencies. Your code can import from
+    // `dependencies` and `peerDependencies` as well as standard Ember-provided
+    // package names.
+    addon.dependencies(),
+
+    // compile TypeScript to latest JavaScript, including Babel transpilation
+    typescript({
+      transpiler: 'babel',
+      browserslist: false,
+      transpileOnly: false,
+    }),
+
+    // Ensure that standalone .hbs files are properly integrated as Javascript.
+    addon.hbs(),
+
+    // addons are allowed to contain imports of .css files, which we want rollup
+    // to leave alone and keep in the published output.
+    addon.keepAssets(['**/*.css']),
+
+    // Remove leftover build artifacts when starting a new build.
+    addon.clean(),
+
+    // Copy Readme and License into published package
+    copy({
+      targets: [
+        { src: '../README.md', dest: '.' },
+        { src: '../LICENSE.md', dest: '.' },
+      ],
+    }),
+  ],
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/unpublished-development-types/index.d.ts
@@ -1,0 +1,2 @@
+// Add any types here that you need for local development only.
+// These will *not* be published as part of your addon, so be careful that your published code does not rely on them!

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/package.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ember-container-query",
+  "version": "3.2.0",
+  "private": true,
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "workspaces": [
+    "ember-container-query",
+    "test-app"
+  ],
+  "scripts": {
+    "build": "pnpm --filter ember-container-query build",
+    "lint": "pnpm --filter '*' lint",
+    "lint:fix": "pnpm --filter '*' lint:fix",
+    "prepare": "pnpm build",
+    "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+    "start:addon": "pnpm --filter ember-container-query start",
+    "start:test-app": "pnpm --filter test-app start",
+    "test": "pnpm --filter '*' test"
+  },
+  "devDependencies": {
+    "concurrently": "^7.6.0",
+    "prettier": "^2.8.3"
+  }
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/pnpm-workspace.yaml
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'ember-container-query'
+  - 'test-app'

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/test-app/ember-cli-build.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/test-app/ember-cli-build.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // Add options here
+    autoImport: {
+      watchDependencies: ['ember-container-query'],
+    },
+  });
+
+  const { maybeEmbroider } = require('@embroider/test-setup');
+
+  return maybeEmbroider(app);
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/test-app/types/global.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/test-app/types/global.d.ts
@@ -1,0 +1,7 @@
+// Types for compiled templates
+declare module 'test-app/templates/*' {
+  import { TemplateFactory } from 'ember-cli-htmlbars';
+
+  const tmpl: TemplateFactory;
+  export default tmpl;
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/.gitignore
@@ -1,0 +1,32 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/.env*
+/.pnp*
+/.sass-cache
+/.eslintcache
+/connect.lock
+/coverage/
+/libpeerconnection.log
+/npm-debug.log*
+/testem.log
+/yarn-error.log
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try
+
+# broccoli-debug
+/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/.prettierignore
@@ -1,0 +1,25 @@
+# unconventional js
+/blueprints/*/files/
+/vendor/
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/coverage/
+!.*
+.*/
+.eslintcache
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/.prettierrc.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/.prettierrc.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  singleQuote: true,
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/.eslintignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/.eslintignore
@@ -1,0 +1,8 @@
+# unconventional js
+/blueprints/*/files/
+
+# compiled output
+/dist/
+
+# misc
+/coverage/

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/addon-main.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/addon-main.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { addonV1Shim } = require('@embroider/addon-shim');
+
+module.exports = addonV1Shim(__dirname);

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/babel.config.json
@@ -1,0 +1,8 @@
+{
+  "presets": [["@babel/preset-typescript"]],
+  "plugins": [
+    "@embroider/addon-dev/template-colocation-plugin",
+    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    "@babel/plugin-proposal-class-properties"
+  ]
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/rollup.config.mjs
@@ -1,0 +1,55 @@
+import typescript from 'rollup-plugin-ts';
+import copy from 'rollup-plugin-copy';
+import { Addon } from '@embroider/addon-dev/rollup';
+
+const addon = new Addon({
+  srcDir: 'src',
+  destDir: 'dist',
+});
+
+export default {
+  // This provides defaults that work well alongside `publicEntrypoints` below.
+  // You can augment this if you need to.
+  output: addon.output(),
+
+  plugins: [
+    // These are the modules that users should be able to import from your
+    // addon. Anything not listed here may get optimized away.
+    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+
+    // These are the modules that should get reexported into the traditional
+    // "app" tree. Things in here should also be in publicEntrypoints above, but
+    // not everything in publicEntrypoints necessarily needs to go here.
+    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+
+    // Follow the V2 Addon rules about dependencies. Your code can import from
+    // `dependencies` and `peerDependencies` as well as standard Ember-provided
+    // package names.
+    addon.dependencies(),
+
+    // compile TypeScript to latest JavaScript, including Babel transpilation
+    typescript({
+      transpiler: 'babel',
+      browserslist: false,
+      transpileOnly: false,
+    }),
+
+    // Ensure that standalone .hbs files are properly integrated as Javascript.
+    addon.hbs(),
+
+    // addons are allowed to contain imports of .css files, which we want rollup
+    // to leave alone and keep in the published output.
+    addon.keepAssets(['**/*.css']),
+
+    // Remove leftover build artifacts when starting a new build.
+    addon.clean(),
+
+    // Copy Readme and License into published package
+    copy({
+      targets: [
+        { src: '../README.md', dest: '.' },
+        { src: '../LICENSE.md', dest: '.' },
+      ],
+    }),
+  ],
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/unpublished-development-types/index.d.ts
@@ -1,4 +1,2 @@
 // Add any types here that you need for local development only.
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
-
-

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/unpublished-development-types/index.d.ts
@@ -1,0 +1,4 @@
+// Add any types here that you need for local development only.
+// These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
+
+

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/package.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/package.json
@@ -16,7 +16,7 @@
     "prepare": "yarn build",
     "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
     "start:addon": "yarn workspace ember-container-query run start",
-    "start:test": "yarn workspace test-app run start",
+    "start:test-app": "yarn workspace test-app run start",
     "test": "yarn workspaces run test"
   },
   "devDependencies": {

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/package.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ember-container-query",
+  "version": "3.2.0",
+  "private": true,
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "workspaces": [
+    "ember-container-query",
+    "test-app"
+  ],
+  "scripts": {
+    "build": "yarn workspace ember-container-query run build",
+    "lint": "yarn workspaces run lint",
+    "lint:fix": "yarn workspaces run lint:fix",
+    "prepare": "yarn build",
+    "start": "concurrently 'npm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
+    "start:addon": "yarn workspace ember-container-query run start",
+    "start:test": "yarn workspace test-app run start",
+    "test": "yarn workspaces run test"
+  },
+  "devDependencies": {
+    "concurrently": "^7.6.0",
+    "prettier": "^2.8.3"
+  }
+}

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/test-app/ember-cli-build.js
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/test-app/ember-cli-build.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // Add options here
+    autoImport: {
+      watchDependencies: ['ember-container-query'],
+    },
+  });
+
+  const { maybeEmbroider } = require('@embroider/test-setup');
+
+  return maybeEmbroider(app);
+};

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/test-app/types/global.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/test-app/types/global.d.ts
@@ -1,0 +1,7 @@
+// Types for compiled templates
+declare module 'test-app/templates/*' {
+  import { TemplateFactory } from 'ember-cli-htmlbars';
+
+  const tmpl: TemplateFactory;
+  export default tmpl;
+}

--- a/tests/fixtures/steps/use-relative-paths/customizations/input/addon/components/container-query.ts
+++ b/tests/fixtures/steps/use-relative-paths/customizations/input/addon/components/container-query.ts
@@ -1,0 +1,49 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type {
+  Dimensions,
+  Features,
+  IndexSignatureParameter,
+  QueryResults,
+} from 'ember-container-query/modifiers/container-query';
+
+interface ContainerQueryComponentSignature<T extends IndexSignatureParameter> {
+  Args: {
+    dataAttributePrefix?: string;
+    debounce?: number;
+    features?: Features<T>;
+    tagName?: string;
+  };
+  Blocks: {
+    default: [
+      {
+        dimensions?: Dimensions;
+        features?: QueryResults<T>;
+      }
+    ];
+  };
+  Element: HTMLElement;
+}
+
+export default class ContainerQueryComponent<
+  T extends IndexSignatureParameter
+> extends Component<ContainerQueryComponentSignature<T>> {
+  @tracked dimensions?: Dimensions;
+  @tracked queryResults?: QueryResults<T>;
+
+  // The dynamic tag is restricted to be immutable
+  tagName = this.args.tagName ?? 'div';
+
+  @action updateState({
+    dimensions,
+    queryResults,
+  }: {
+    dimensions: Dimensions;
+    queryResults: QueryResults<T>;
+  }): void {
+    this.dimensions = dimensions;
+    this.queryResults = queryResults;
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/customizations/input/tests/dummy/app/app.ts
+++ b/tests/fixtures/steps/use-relative-paths/customizations/input/tests/dummy/app/app.ts
@@ -1,0 +1,12 @@
+import Application from '@ember/application';
+import config from 'dummy/config/environment';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from 'ember-resolver';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);

--- a/tests/fixtures/steps/use-relative-paths/customizations/input/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/use-relative-paths/customizations/input/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,28 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import type { Image } from 'dummy/data/concert';
+import { findBestFittingImage } from 'dummy/utils/components/widgets/widget-3';
+import type { Dimensions } from 'ember-container-query/modifiers/container-query';
+
+interface WidgetsWidget3TourScheduleResponsiveImageComponentSignature {
+  Args: {
+    images: Array<Image>;
+  };
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentSignature> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget-3::TourSchedule::ResponsiveImage': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/customizations/output/addon/components/container-query.ts
+++ b/tests/fixtures/steps/use-relative-paths/customizations/output/addon/components/container-query.ts
@@ -1,0 +1,49 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type {
+  Dimensions,
+  Features,
+  IndexSignatureParameter,
+  QueryResults,
+} from '../modifiers/container-query';
+
+interface ContainerQueryComponentSignature<T extends IndexSignatureParameter> {
+  Args: {
+    dataAttributePrefix?: string;
+    debounce?: number;
+    features?: Features<T>;
+    tagName?: string;
+  };
+  Blocks: {
+    default: [
+      {
+        dimensions?: Dimensions;
+        features?: QueryResults<T>;
+      }
+    ];
+  };
+  Element: HTMLElement;
+}
+
+export default class ContainerQueryComponent<
+  T extends IndexSignatureParameter
+> extends Component<ContainerQueryComponentSignature<T>> {
+  @tracked dimensions?: Dimensions;
+  @tracked queryResults?: QueryResults<T>;
+
+  // The dynamic tag is restricted to be immutable
+  tagName = this.args.tagName ?? 'div';
+
+  @action updateState({
+    dimensions,
+    queryResults,
+  }: {
+    dimensions: Dimensions;
+    queryResults: QueryResults<T>;
+  }): void {
+    this.dimensions = dimensions;
+    this.queryResults = queryResults;
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/customizations/output/tests/dummy/app/app.ts
+++ b/tests/fixtures/steps/use-relative-paths/customizations/output/tests/dummy/app/app.ts
@@ -1,0 +1,12 @@
+import Application from '@ember/application';
+import config from './config/environment';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from 'ember-resolver';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);

--- a/tests/fixtures/steps/use-relative-paths/customizations/output/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/use-relative-paths/customizations/output/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,28 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import type { Image } from '../../../../data/concert';
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+import type { Dimensions } from 'ember-container-query/modifiers/container-query';
+
+interface WidgetsWidget3TourScheduleResponsiveImageComponentSignature {
+  Args: {
+    images: Array<Image>;
+  };
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentSignature> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget-3::TourSchedule::ResponsiveImage': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/javascript/input/addon/components/container-query.js
+++ b/tests/fixtures/steps/use-relative-paths/javascript/input/addon/components/container-query.js
@@ -1,0 +1,16 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class ContainerQueryComponent extends Component {
+  @tracked dimensions;
+  @tracked queryResults;
+
+  // The dynamic tag is restricted to be immutable
+  tagName = this.args.tagName ?? 'div';
+
+  @action updateState({ dimensions, queryResults }) {
+    this.dimensions = dimensions;
+    this.queryResults = queryResults;
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/javascript/input/tests/dummy/app/app.js
+++ b/tests/fixtures/steps/use-relative-paths/javascript/input/tests/dummy/app/app.js
@@ -1,0 +1,12 @@
+import Application from '@ember/application';
+import config from 'dummy/config/environment';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from 'ember-resolver';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);

--- a/tests/fixtures/steps/use-relative-paths/javascript/input/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.js
+++ b/tests/fixtures/steps/use-relative-paths/javascript/input/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.js
@@ -1,0 +1,14 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { findBestFittingImage } from 'dummy/utils/components/widgets/widget-3';
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component {
+  @tracked imageSource;
+
+  @action setImageSource({ dimensions }) {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/javascript/output/addon/components/container-query.js
+++ b/tests/fixtures/steps/use-relative-paths/javascript/output/addon/components/container-query.js
@@ -1,0 +1,16 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class ContainerQueryComponent extends Component {
+  @tracked dimensions;
+  @tracked queryResults;
+
+  // The dynamic tag is restricted to be immutable
+  tagName = this.args.tagName ?? 'div';
+
+  @action updateState({ dimensions, queryResults }) {
+    this.dimensions = dimensions;
+    this.queryResults = queryResults;
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/javascript/output/tests/dummy/app/app.js
+++ b/tests/fixtures/steps/use-relative-paths/javascript/output/tests/dummy/app/app.js
@@ -1,0 +1,12 @@
+import Application from '@ember/application';
+import config from './config/environment';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from 'ember-resolver';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);

--- a/tests/fixtures/steps/use-relative-paths/javascript/output/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.js
+++ b/tests/fixtures/steps/use-relative-paths/javascript/output/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.js
@@ -1,0 +1,14 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component {
+  @tracked imageSource;
+
+  @action setImageSource({ dimensions }) {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/typescript/input/addon/components/container-query.ts
+++ b/tests/fixtures/steps/use-relative-paths/typescript/input/addon/components/container-query.ts
@@ -1,0 +1,49 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type {
+  Dimensions,
+  Features,
+  IndexSignatureParameter,
+  QueryResults,
+} from 'ember-container-query/modifiers/container-query';
+
+interface ContainerQueryComponentSignature<T extends IndexSignatureParameter> {
+  Args: {
+    dataAttributePrefix?: string;
+    debounce?: number;
+    features?: Features<T>;
+    tagName?: string;
+  };
+  Blocks: {
+    default: [
+      {
+        dimensions?: Dimensions;
+        features?: QueryResults<T>;
+      }
+    ];
+  };
+  Element: HTMLElement;
+}
+
+export default class ContainerQueryComponent<
+  T extends IndexSignatureParameter
+> extends Component<ContainerQueryComponentSignature<T>> {
+  @tracked dimensions?: Dimensions;
+  @tracked queryResults?: QueryResults<T>;
+
+  // The dynamic tag is restricted to be immutable
+  tagName = this.args.tagName ?? 'div';
+
+  @action updateState({
+    dimensions,
+    queryResults,
+  }: {
+    dimensions: Dimensions;
+    queryResults: QueryResults<T>;
+  }): void {
+    this.dimensions = dimensions;
+    this.queryResults = queryResults;
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/typescript/input/tests/dummy/app/app.ts
+++ b/tests/fixtures/steps/use-relative-paths/typescript/input/tests/dummy/app/app.ts
@@ -1,0 +1,12 @@
+import Application from '@ember/application';
+import config from 'dummy/config/environment';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from 'ember-resolver';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);

--- a/tests/fixtures/steps/use-relative-paths/typescript/input/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/use-relative-paths/typescript/input/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,28 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import type { Image } from 'dummy/data/concert';
+import { findBestFittingImage } from 'dummy/utils/components/widgets/widget-3';
+import type { Dimensions } from 'ember-container-query/modifiers/container-query';
+
+interface WidgetsWidget3TourScheduleResponsiveImageComponentSignature {
+  Args: {
+    images: Array<Image>;
+  };
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentSignature> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget-3::TourSchedule::ResponsiveImage': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/typescript/output/addon/components/container-query.ts
+++ b/tests/fixtures/steps/use-relative-paths/typescript/output/addon/components/container-query.ts
@@ -1,0 +1,49 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+import type {
+  Dimensions,
+  Features,
+  IndexSignatureParameter,
+  QueryResults,
+} from '../modifiers/container-query';
+
+interface ContainerQueryComponentSignature<T extends IndexSignatureParameter> {
+  Args: {
+    dataAttributePrefix?: string;
+    debounce?: number;
+    features?: Features<T>;
+    tagName?: string;
+  };
+  Blocks: {
+    default: [
+      {
+        dimensions?: Dimensions;
+        features?: QueryResults<T>;
+      }
+    ];
+  };
+  Element: HTMLElement;
+}
+
+export default class ContainerQueryComponent<
+  T extends IndexSignatureParameter
+> extends Component<ContainerQueryComponentSignature<T>> {
+  @tracked dimensions?: Dimensions;
+  @tracked queryResults?: QueryResults<T>;
+
+  // The dynamic tag is restricted to be immutable
+  tagName = this.args.tagName ?? 'div';
+
+  @action updateState({
+    dimensions,
+    queryResults,
+  }: {
+    dimensions: Dimensions;
+    queryResults: QueryResults<T>;
+  }): void {
+    this.dimensions = dimensions;
+    this.queryResults = queryResults;
+  }
+}

--- a/tests/fixtures/steps/use-relative-paths/typescript/output/tests/dummy/app/app.ts
+++ b/tests/fixtures/steps/use-relative-paths/typescript/output/tests/dummy/app/app.ts
@@ -1,0 +1,12 @@
+import Application from '@ember/application';
+import config from './config/environment';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from 'ember-resolver';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);

--- a/tests/fixtures/steps/use-relative-paths/typescript/output/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
+++ b/tests/fixtures/steps/use-relative-paths/typescript/output/tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts
@@ -1,0 +1,28 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import type { Image } from '../../../../data/concert';
+import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';
+import type { Dimensions } from 'ember-container-query/modifiers/container-query';
+
+interface WidgetsWidget3TourScheduleResponsiveImageComponentSignature {
+  Args: {
+    images: Array<Image>;
+  };
+}
+
+export default class WidgetsWidget3TourScheduleResponsiveImageComponent extends Component<WidgetsWidget3TourScheduleResponsiveImageComponentSignature> {
+  @tracked imageSource?: string;
+
+  @action setImageSource({ dimensions }: { dimensions: Dimensions }): void {
+    const { images } = this.args;
+
+    this.imageSource = findBestFittingImage(images, dimensions);
+  }
+}
+
+declare module '@glint/environment-ember-loose/registry' {
+  export default interface Registry {
+    'Widgets::Widget-3::TourSchedule::ResponsiveImage': typeof WidgetsWidget3TourScheduleResponsiveImageComponent;
+  }
+}

--- a/tests/migration/ember-addon/index/ember-container-query/customizations.test.js
+++ b/tests/migration/ember-addon/index/ember-container-query/customizations.test.js
@@ -9,7 +9,7 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-test('migration | ember-addon | index > ember-container-query-customizations', function () {
+test('migration | ember-addon | index | ember-container-query > customizations', function () {
   const options = {
     addonLocation: 'packages/ember-container-query',
     projectRoot: 'tmp/ember-container-query-customizations',

--- a/tests/migration/ember-addon/index/ember-container-query/javascript.test.js
+++ b/tests/migration/ember-addon/index/ember-container-query/javascript.test.js
@@ -9,7 +9,7 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-test('migration | ember-addon | index > ember-container-query-javascript', function () {
+test('migration | ember-addon | index | ember-container-query > javascript', function () {
   const options = {
     addonLocation: undefined,
     projectRoot: 'tmp/ember-container-query-javascript',

--- a/tests/migration/ember-addon/index/ember-container-query/typescript.test.js
+++ b/tests/migration/ember-addon/index/ember-container-query/typescript.test.js
@@ -9,7 +9,7 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-test('migration | ember-addon | index > ember-container-query-typescript', function () {
+test('migration | ember-addon | index | ember-container-query > typescript', function () {
   const options = {
     addonLocation: undefined,
     projectRoot: 'tmp/ember-container-query-typescript',

--- a/tests/migration/ember-addon/index/new-v1-addon/customizations.test.js
+++ b/tests/migration/ember-addon/index/new-v1-addon/customizations.test.js
@@ -9,7 +9,7 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-test('migration | ember-addon | index > new-v1-addon-customizations', function () {
+test('migration | ember-addon | index | new-v1-addon > customizations', function () {
   const options = {
     addonLocation: 'packages/new-v1-addon',
     projectRoot: 'tmp/new-v1-addon-customizations',

--- a/tests/migration/ember-addon/index/new-v1-addon/javascript.test.js
+++ b/tests/migration/ember-addon/index/new-v1-addon/javascript.test.js
@@ -9,7 +9,7 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-test('migration | ember-addon | index > new-v1-addon-javascript', function () {
+test('migration | ember-addon | index | new-v1-addon > javascript', function () {
   const options = {
     addonLocation: undefined,
     projectRoot: 'tmp/new-v1-addon-javascript',

--- a/tests/migration/ember-addon/index/new-v1-addon/npm.test.js
+++ b/tests/migration/ember-addon/index/new-v1-addon/npm.test.js
@@ -9,7 +9,7 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-test('migration | ember-addon | index > new-v1-addon-npm', function () {
+test('migration | ember-addon | index | new-v1-addon > npm', function () {
   const options = {
     addonLocation: undefined,
     projectRoot: 'tmp/new-v1-addon-npm',

--- a/tests/migration/ember-addon/index/new-v1-addon/pnpm.test.js
+++ b/tests/migration/ember-addon/index/new-v1-addon/pnpm.test.js
@@ -9,7 +9,7 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-test('migration | ember-addon | index > new-v1-addon-pnpm', function () {
+test('migration | ember-addon | index | new-v1-addon > pnpm', function () {
   const options = {
     addonLocation: undefined,
     projectRoot: 'tmp/new-v1-addon-pnpm',

--- a/tests/migration/ember-addon/index/new-v1-addon/typescript.test.js
+++ b/tests/migration/ember-addon/index/new-v1-addon/typescript.test.js
@@ -9,7 +9,7 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-test('migration | ember-addon | index > new-v1-addon-typescript', function () {
+test('migration | ember-addon | index | new-v1-addon > typescript', function () {
   const options = {
     addonLocation: undefined,
     projectRoot: 'tmp/new-v1-addon-typescript',

--- a/tests/migration/ember-addon/steps/create-files-from-blueprint/customizations.test.js
+++ b/tests/migration/ember-addon/steps/create-files-from-blueprint/customizations.test.js
@@ -1,0 +1,44 @@
+import { createFilesFromBlueprint } from '../../../../../src/migration/ember-addon/steps/create-files-from-blueprint.js';
+import { convertToJson } from '../../../../helpers/fixture.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/customizations.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-files-from-blueprint > customizations', function () {
+  const inputProject = {};
+
+  const outputProject = convertToJson(
+    'steps/create-files-from-blueprint/customizations/output'
+  );
+
+  loadFixture(inputProject, options);
+
+  const context = {
+    appReexports: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'modifiers/container-query.js',
+    ],
+    publicEntrypoints: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'index.js',
+      'modifiers/container-query.js',
+      'template-registry.js',
+    ],
+  };
+
+  createFilesFromBlueprint(context, augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/create-files-from-blueprint/glint.test.js
+++ b/tests/migration/ember-addon/steps/create-files-from-blueprint/glint.test.js
@@ -1,0 +1,72 @@
+import { createFilesFromBlueprint } from '../../../../../src/migration/ember-addon/steps/create-files-from-blueprint.js';
+import { convertToJson } from '../../../../helpers/fixture.js';
+import { options } from '../../../../helpers/shared-test-setups/typescript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-files-from-blueprint > glint', function () {
+  const inputProject = {};
+
+  const outputProject = convertToJson(
+    'steps/create-files-from-blueprint/glint/output'
+  );
+
+  loadFixture(inputProject, options);
+
+  const augmentedOptions = {
+    locations: {
+      addon: 'ember-container-query',
+      testApp: 'test-app',
+    },
+    packageManager: {
+      isNpm: false,
+      isPnpm: false,
+      isYarn: true,
+    },
+    packages: {
+      addon: {
+        dependencies: new Map([
+          ['ember-cli-babel', '^7.26.11'],
+          ['ember-cli-htmlbars', '^6.1.1'],
+          ['@glint/core', '^v1.0.0-beta.2'],
+          ['typescript', '^4.9.4'],
+        ]),
+        hasGlint: true,
+        hasTypeScript: true,
+        isV1Addon: true,
+        name: 'ember-container-query',
+        version: '3.2.0',
+      },
+      testApp: {
+        name: 'test-app',
+      },
+    },
+    projectRoot: 'tmp/ember-container-query-typescript',
+  };
+
+  const context = {
+    appReexports: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'modifiers/container-query.js',
+    ],
+    publicEntrypoints: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'index.js',
+      'modifiers/container-query.js',
+      'template-registry.js',
+    ],
+  };
+
+  createFilesFromBlueprint(context, augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/create-files-from-blueprint/javascript.test.js
+++ b/tests/migration/ember-addon/steps/create-files-from-blueprint/javascript.test.js
@@ -1,0 +1,42 @@
+import { createFilesFromBlueprint } from '../../../../../src/migration/ember-addon/steps/create-files-from-blueprint.js';
+import { convertToJson } from '../../../../helpers/fixture.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/javascript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-files-from-blueprint > javascript', function () {
+  const inputProject = {};
+
+  const outputProject = convertToJson(
+    'steps/create-files-from-blueprint/javascript/output'
+  );
+
+  loadFixture(inputProject, options);
+
+  const context = {
+    appReexports: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'modifiers/container-query.js',
+    ],
+    publicEntrypoints: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'modifiers/container-query.js',
+    ],
+  };
+
+  createFilesFromBlueprint(context, augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/create-files-from-blueprint/npm.test.js
+++ b/tests/migration/ember-addon/steps/create-files-from-blueprint/npm.test.js
@@ -1,0 +1,71 @@
+import { createFilesFromBlueprint } from '../../../../../src/migration/ember-addon/steps/create-files-from-blueprint.js';
+import { convertToJson } from '../../../../helpers/fixture.js';
+import { options } from '../../../../helpers/shared-test-setups/typescript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-files-from-blueprint > npm', function () {
+  const inputProject = {};
+
+  const outputProject = convertToJson(
+    'steps/create-files-from-blueprint/npm/output'
+  );
+
+  loadFixture(inputProject, options);
+
+  const augmentedOptions = {
+    locations: {
+      addon: 'ember-container-query',
+      testApp: 'test-app',
+    },
+    packageManager: {
+      isNpm: true,
+      isPnpm: false,
+      isYarn: false,
+    },
+    packages: {
+      addon: {
+        dependencies: new Map([
+          ['ember-cli-babel', '^7.26.11'],
+          ['ember-cli-htmlbars', '^6.1.1'],
+          ['typescript', '^4.9.4'],
+        ]),
+        hasGlint: false,
+        hasTypeScript: true,
+        isV1Addon: true,
+        name: 'ember-container-query',
+        version: '3.2.0',
+      },
+      testApp: {
+        name: 'test-app',
+      },
+    },
+    projectRoot: 'tmp/ember-container-query-typescript',
+  };
+
+  const context = {
+    appReexports: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'modifiers/container-query.js',
+    ],
+    publicEntrypoints: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'index.js',
+      'modifiers/container-query.js',
+      'template-registry.js',
+    ],
+  };
+
+  createFilesFromBlueprint(context, augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/create-files-from-blueprint/pnpm.test.js
+++ b/tests/migration/ember-addon/steps/create-files-from-blueprint/pnpm.test.js
@@ -1,0 +1,71 @@
+import { createFilesFromBlueprint } from '../../../../../src/migration/ember-addon/steps/create-files-from-blueprint.js';
+import { convertToJson } from '../../../../helpers/fixture.js';
+import { options } from '../../../../helpers/shared-test-setups/typescript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-files-from-blueprint > pnpm', function () {
+  const inputProject = {};
+
+  const outputProject = convertToJson(
+    'steps/create-files-from-blueprint/pnpm/output'
+  );
+
+  loadFixture(inputProject, options);
+
+  const augmentedOptions = {
+    locations: {
+      addon: 'ember-container-query',
+      testApp: 'test-app',
+    },
+    packageManager: {
+      isNpm: false,
+      isPnpm: true,
+      isYarn: false,
+    },
+    packages: {
+      addon: {
+        dependencies: new Map([
+          ['ember-cli-babel', '^7.26.11'],
+          ['ember-cli-htmlbars', '^6.1.1'],
+          ['typescript', '^4.9.4'],
+        ]),
+        hasGlint: false,
+        hasTypeScript: true,
+        isV1Addon: true,
+        name: 'ember-container-query',
+        version: '3.2.0',
+      },
+      testApp: {
+        name: 'test-app',
+      },
+    },
+    projectRoot: 'tmp/ember-container-query-typescript',
+  };
+
+  const context = {
+    appReexports: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'modifiers/container-query.js',
+    ],
+    publicEntrypoints: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'index.js',
+      'modifiers/container-query.js',
+      'template-registry.js',
+    ],
+  };
+
+  createFilesFromBlueprint(context, augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/create-files-from-blueprint/typescript.test.js
+++ b/tests/migration/ember-addon/steps/create-files-from-blueprint/typescript.test.js
@@ -1,0 +1,44 @@
+import { createFilesFromBlueprint } from '../../../../../src/migration/ember-addon/steps/create-files-from-blueprint.js';
+import { convertToJson } from '../../../../helpers/fixture.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/typescript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | create-files-from-blueprint > typescript', function () {
+  const inputProject = {};
+
+  const outputProject = convertToJson(
+    'steps/create-files-from-blueprint/typescript/output'
+  );
+
+  loadFixture(inputProject, options);
+
+  const context = {
+    appReexports: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'modifiers/container-query.js',
+    ],
+    publicEntrypoints: [
+      'components/container-query.js',
+      'helpers/aspect-ratio.js',
+      'helpers/height.js',
+      'helpers/width.js',
+      'index.js',
+      'modifiers/container-query.js',
+      'template-registry.js',
+    ],
+  };
+
+  createFilesFromBlueprint(context, augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/move-project-root-files/customizations.test.js
+++ b/tests/migration/ember-addon/steps/move-project-root-files/customizations.test.js
@@ -53,6 +53,7 @@ test('migration | ember-addon | steps | move-project-root-files > customizations
     },
     packages: {
       'ember-container-query': {
+        '.eslintignore': 'some code for .eslintignore',
         '.eslintrc.js': 'some code for .eslintrc.js',
         '.gitignore': 'some code for .gitignore',
         '.prettierignore': 'some code for .prettierignore',

--- a/tests/migration/ember-addon/steps/move-project-root-files/customizations.test.js
+++ b/tests/migration/ember-addon/steps/move-project-root-files/customizations.test.js
@@ -1,0 +1,82 @@
+import { moveProjectRootFiles } from '../../../../../src/migration/ember-addon/steps/move-project-root-files.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/customizations.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | move-project-root-files > customizations', function () {
+  const inputProject = {
+    '.editorconfig': 'some code for .editorconfig',
+    '.ember-cli': 'some code for .ember-cli',
+    '.eslintignore': 'some code for .eslintignore',
+    '.eslintrc.js': 'some code for .eslintrc.js',
+    '.gitignore': 'some code for .gitignore',
+    '.netlifyredirects': 'some code for .netlifyredirects',
+    '.npmignore': 'some code for .npmignore',
+    '.prettierignore': 'some code for .prettierignore',
+    '.prettierrc.js': 'some code for .prettierrc.js',
+    '.stylelintrc.js': 'some code for .stylelintrc.js',
+    '.template-lintrc.js': 'some code for .template-lintrc.js',
+    '.watchmanconfig': 'some code for .watchmanconfig',
+    'CHANGELOG.md': 'some code for CHANGELOG.md',
+    'CONTRIBUTING.md': 'some code for CONTRIBUTING.md',
+    'ember-cli-build.js': 'some code for ember-cli-build.js',
+    'index.js': 'some code for index.js',
+    'LICENSE.md': 'some code for LICENSE.md',
+    'package.json': 'some code for package.json',
+    'README.md': 'some code for README.md',
+    'testem.js': 'some code for testem.js',
+    'tsconfig.json': 'some code for tsconfig.json',
+    'yarn.lock': 'some code for yarn.lock',
+  };
+
+  const outputProject = {
+    'demo-app': {
+      '.ember-cli': 'some code for .ember-cli',
+      '.eslintignore': 'some code for .eslintignore',
+      '.eslintrc.js': 'some code for .eslintrc.js',
+      '.gitignore': 'some code for .gitignore',
+      '.prettierignore': 'some code for .prettierignore',
+      '.prettierrc.js': 'some code for .prettierrc.js',
+      '.stylelintrc.js': 'some code for .stylelintrc.js',
+      '.template-lintrc.js': 'some code for .template-lintrc.js',
+      '.watchmanconfig': 'some code for .watchmanconfig',
+      'ember-cli-build.js': 'some code for ember-cli-build.js',
+      'package.json': 'some code for package.json',
+      'testem.js': 'some code for testem.js',
+      'tsconfig.json': 'some code for tsconfig.json',
+    },
+    packages: {
+      'ember-container-query': {
+        '.eslintrc.js': 'some code for .eslintrc.js',
+        '.gitignore': 'some code for .gitignore',
+        '.prettierignore': 'some code for .prettierignore',
+        '.prettierrc.js': 'some code for .prettierrc.js',
+        '.stylelintrc.js': 'some code for .stylelintrc.js',
+        '.template-lintrc.js': 'some code for .template-lintrc.js',
+        'LICENSE.md': 'some code for LICENSE.md',
+        'package.json': 'some code for package.json',
+        'README.md': 'some code for README.md',
+        'tsconfig.json': 'some code for tsconfig.json',
+      },
+    },
+    '.editorconfig': 'some code for .editorconfig',
+    '.netlifyredirects': 'some code for .netlifyredirects',
+    'CHANGELOG.md': 'some code for CHANGELOG.md',
+    'CONTRIBUTING.md': 'some code for CONTRIBUTING.md',
+    'LICENSE.md': 'some code for LICENSE.md',
+    'README.md': 'some code for README.md',
+    'yarn.lock': 'some code for yarn.lock',
+  };
+
+  loadFixture(inputProject, options);
+
+  moveProjectRootFiles(augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/move-project-root-files/edge-case-folders-are-missing.test.js
+++ b/tests/migration/ember-addon/steps/move-project-root-files/edge-case-folders-are-missing.test.js
@@ -1,0 +1,22 @@
+import { moveProjectRootFiles } from '../../../../../src/migration/ember-addon/steps/move-project-root-files.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/typescript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | move-project-root-files > edge case (folders are missing)', function () {
+  const inputProject = {};
+
+  const outputProject = {};
+
+  loadFixture(inputProject, options);
+
+  moveProjectRootFiles(augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/move-project-root-files/javascript.test.js
+++ b/tests/migration/ember-addon/steps/move-project-root-files/javascript.test.js
@@ -36,6 +36,7 @@ test('migration | ember-addon | steps | move-project-root-files > javascript', f
 
   const outputProject = {
     'ember-container-query': {
+      '.eslintignore': 'some code for .eslintignore',
       '.eslintrc.js': 'some code for .eslintrc.js',
       '.gitignore': 'some code for .gitignore',
       '.prettierignore': 'some code for .prettierignore',

--- a/tests/migration/ember-addon/steps/move-project-root-files/javascript.test.js
+++ b/tests/migration/ember-addon/steps/move-project-root-files/javascript.test.js
@@ -1,0 +1,77 @@
+import { moveProjectRootFiles } from '../../../../../src/migration/ember-addon/steps/move-project-root-files.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/javascript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | move-project-root-files > javascript', function () {
+  const inputProject = {
+    '.editorconfig': 'some code for .editorconfig',
+    '.ember-cli': 'some code for .ember-cli',
+    '.eslintignore': 'some code for .eslintignore',
+    '.eslintrc.js': 'some code for .eslintrc.js',
+    '.gitignore': 'some code for .gitignore',
+    '.netlifyredirects': 'some code for .netlifyredirects',
+    '.npmignore': 'some code for .npmignore',
+    '.prettierignore': 'some code for .prettierignore',
+    '.prettierrc.js': 'some code for .prettierrc.js',
+    '.stylelintrc.js': 'some code for .stylelintrc.js',
+    '.template-lintrc.js': 'some code for .template-lintrc.js',
+    '.watchmanconfig': 'some code for .watchmanconfig',
+    'CHANGELOG.md': 'some code for CHANGELOG.md',
+    'CONTRIBUTING.md': 'some code for CONTRIBUTING.md',
+    'ember-cli-build.js': 'some code for ember-cli-build.js',
+    'index.js': 'some code for index.js',
+    'LICENSE.md': 'some code for LICENSE.md',
+    'package.json': 'some code for package.json',
+    'README.md': 'some code for README.md',
+    'testem.js': 'some code for testem.js',
+    'yarn.lock': 'some code for yarn.lock',
+  };
+
+  const outputProject = {
+    'ember-container-query': {
+      '.eslintrc.js': 'some code for .eslintrc.js',
+      '.gitignore': 'some code for .gitignore',
+      '.prettierignore': 'some code for .prettierignore',
+      '.prettierrc.js': 'some code for .prettierrc.js',
+      '.stylelintrc.js': 'some code for .stylelintrc.js',
+      '.template-lintrc.js': 'some code for .template-lintrc.js',
+      'LICENSE.md': 'some code for LICENSE.md',
+      'package.json': 'some code for package.json',
+      'README.md': 'some code for README.md',
+    },
+    'test-app': {
+      '.ember-cli': 'some code for .ember-cli',
+      '.eslintignore': 'some code for .eslintignore',
+      '.eslintrc.js': 'some code for .eslintrc.js',
+      '.gitignore': 'some code for .gitignore',
+      '.prettierignore': 'some code for .prettierignore',
+      '.prettierrc.js': 'some code for .prettierrc.js',
+      '.stylelintrc.js': 'some code for .stylelintrc.js',
+      '.template-lintrc.js': 'some code for .template-lintrc.js',
+      '.watchmanconfig': 'some code for .watchmanconfig',
+      'ember-cli-build.js': 'some code for ember-cli-build.js',
+      'package.json': 'some code for package.json',
+      'testem.js': 'some code for testem.js',
+    },
+    '.editorconfig': 'some code for .editorconfig',
+    '.netlifyredirects': 'some code for .netlifyredirects',
+    'CHANGELOG.md': 'some code for CHANGELOG.md',
+    'CONTRIBUTING.md': 'some code for CONTRIBUTING.md',
+    'LICENSE.md': 'some code for LICENSE.md',
+    'README.md': 'some code for README.md',
+    'yarn.lock': 'some code for yarn.lock',
+  };
+
+  loadFixture(inputProject, options);
+
+  moveProjectRootFiles(augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/move-project-root-files/typescript.test.js
+++ b/tests/migration/ember-addon/steps/move-project-root-files/typescript.test.js
@@ -1,0 +1,80 @@
+import { moveProjectRootFiles } from '../../../../../src/migration/ember-addon/steps/move-project-root-files.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/typescript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | move-project-root-files > typescript', function () {
+  const inputProject = {
+    '.editorconfig': 'some code for .editorconfig',
+    '.ember-cli': 'some code for .ember-cli',
+    '.eslintignore': 'some code for .eslintignore',
+    '.eslintrc.js': 'some code for .eslintrc.js',
+    '.gitignore': 'some code for .gitignore',
+    '.netlifyredirects': 'some code for .netlifyredirects',
+    '.npmignore': 'some code for .npmignore',
+    '.prettierignore': 'some code for .prettierignore',
+    '.prettierrc.js': 'some code for .prettierrc.js',
+    '.stylelintrc.js': 'some code for .stylelintrc.js',
+    '.template-lintrc.js': 'some code for .template-lintrc.js',
+    '.watchmanconfig': 'some code for .watchmanconfig',
+    'CHANGELOG.md': 'some code for CHANGELOG.md',
+    'CONTRIBUTING.md': 'some code for CONTRIBUTING.md',
+    'ember-cli-build.js': 'some code for ember-cli-build.js',
+    'index.js': 'some code for index.js',
+    'LICENSE.md': 'some code for LICENSE.md',
+    'package.json': 'some code for package.json',
+    'README.md': 'some code for README.md',
+    'testem.js': 'some code for testem.js',
+    'tsconfig.json': 'some code for tsconfig.json',
+    'yarn.lock': 'some code for yarn.lock',
+  };
+
+  const outputProject = {
+    'ember-container-query': {
+      '.eslintrc.js': 'some code for .eslintrc.js',
+      '.gitignore': 'some code for .gitignore',
+      '.prettierignore': 'some code for .prettierignore',
+      '.prettierrc.js': 'some code for .prettierrc.js',
+      '.stylelintrc.js': 'some code for .stylelintrc.js',
+      '.template-lintrc.js': 'some code for .template-lintrc.js',
+      'LICENSE.md': 'some code for LICENSE.md',
+      'package.json': 'some code for package.json',
+      'README.md': 'some code for README.md',
+      'tsconfig.json': 'some code for tsconfig.json',
+    },
+    'test-app': {
+      '.ember-cli': 'some code for .ember-cli',
+      '.eslintignore': 'some code for .eslintignore',
+      '.eslintrc.js': 'some code for .eslintrc.js',
+      '.gitignore': 'some code for .gitignore',
+      '.prettierignore': 'some code for .prettierignore',
+      '.prettierrc.js': 'some code for .prettierrc.js',
+      '.stylelintrc.js': 'some code for .stylelintrc.js',
+      '.template-lintrc.js': 'some code for .template-lintrc.js',
+      '.watchmanconfig': 'some code for .watchmanconfig',
+      'ember-cli-build.js': 'some code for ember-cli-build.js',
+      'package.json': 'some code for package.json',
+      'testem.js': 'some code for testem.js',
+      'tsconfig.json': 'some code for tsconfig.json',
+    },
+    '.editorconfig': 'some code for .editorconfig',
+    '.netlifyredirects': 'some code for .netlifyredirects',
+    'CHANGELOG.md': 'some code for CHANGELOG.md',
+    'CONTRIBUTING.md': 'some code for CONTRIBUTING.md',
+    'LICENSE.md': 'some code for LICENSE.md',
+    'README.md': 'some code for README.md',
+    'yarn.lock': 'some code for yarn.lock',
+  };
+
+  loadFixture(inputProject, options);
+
+  moveProjectRootFiles(augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/move-project-root-files/typescript.test.js
+++ b/tests/migration/ember-addon/steps/move-project-root-files/typescript.test.js
@@ -37,6 +37,7 @@ test('migration | ember-addon | steps | move-project-root-files > typescript', f
 
   const outputProject = {
     'ember-container-query': {
+      '.eslintignore': 'some code for .eslintignore',
       '.eslintrc.js': 'some code for .eslintrc.js',
       '.gitignore': 'some code for .gitignore',
       '.prettierignore': 'some code for .prettierignore',

--- a/tests/migration/ember-addon/steps/move-test-app-files/customizations.test.js
+++ b/tests/migration/ember-addon/steps/move-test-app-files/customizations.test.js
@@ -1,0 +1,170 @@
+import { moveTestAppFiles } from '../../../../../src/migration/ember-addon/steps/move-test-app-files.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/customizations.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | move-test-app-files > customizations', function () {
+  const inputProject = {
+    tests: {
+      acceptance: {
+        album: {
+          'accessibility-test.ts': '',
+          'visual-regression-test.ts': '',
+        },
+      },
+      dummy: {
+        app: {
+          components: {
+            '.gitkeep': '',
+          },
+          config: {
+            'environment.d.ts': '',
+          },
+          routes: {
+            '.gitkeep': '',
+          },
+          templates: {
+            '.gitkeep': '',
+          },
+          'app.ts': '',
+          'index.html': '',
+          'router.ts': '',
+        },
+        config: {
+          'ember-cli-update.json': '',
+          'ember-try.js': '',
+          'environment.js': '',
+          'optional-features.json': '',
+          'targets.js': '',
+        },
+        public: {
+          assets: {
+            'favicon.png': '',
+          },
+          'robots.txt': '',
+        },
+      },
+      helpers: {
+        'index.ts': '',
+      },
+      integration: {
+        components: {
+          'container-query': {
+            'dataAttributePrefix-test.ts': '',
+            'debounce-test.ts': '',
+            'features-test.ts': '',
+            'splattributes-test.ts': '',
+            'tagName-test.ts': '',
+          },
+        },
+      },
+      unit: {
+        utils: {
+          components: {
+            widgets: {
+              'widget-2-test.ts': '',
+              'widget-3-test.ts': '',
+            },
+          },
+        },
+        '.gitkeep': '',
+      },
+      'index.html': '',
+      'test-helper.ts': '',
+    },
+    types: {
+      dummy: {
+        'index.d.ts': '',
+      },
+      'global.d.ts': '',
+    },
+  };
+
+  const outputProject = {
+    'demo-app': {
+      app: {
+        components: {
+          '.gitkeep': '',
+        },
+        config: {
+          'environment.d.ts': '',
+        },
+        routes: {
+          '.gitkeep': '',
+        },
+        templates: {
+          '.gitkeep': '',
+        },
+        'app.ts': '',
+        'index.html': '',
+        'router.ts': '',
+      },
+      config: {
+        'ember-cli-update.json': '',
+        'ember-try.js': '',
+        'environment.js': '',
+        'optional-features.json': '',
+        'targets.js': '',
+      },
+      public: {
+        assets: {
+          'favicon.png': '',
+        },
+        'robots.txt': '',
+      },
+      tests: {
+        acceptance: {
+          album: {
+            'accessibility-test.ts': '',
+            'visual-regression-test.ts': '',
+          },
+        },
+        helpers: {
+          'index.ts': '',
+        },
+        integration: {
+          components: {
+            'container-query': {
+              'dataAttributePrefix-test.ts': '',
+              'debounce-test.ts': '',
+              'features-test.ts': '',
+              'splattributes-test.ts': '',
+              'tagName-test.ts': '',
+            },
+          },
+        },
+        unit: {
+          utils: {
+            components: {
+              widgets: {
+                'widget-2-test.ts': '',
+                'widget-3-test.ts': '',
+              },
+            },
+          },
+          '.gitkeep': '',
+        },
+        'index.html': '',
+        'test-helper.ts': '',
+      },
+      types: {
+        'demo-app-for-ember-container-query': {
+          'index.d.ts': '',
+        },
+        'global.d.ts': '',
+      },
+    },
+  };
+
+  loadFixture(inputProject, options);
+
+  moveTestAppFiles(augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/move-test-app-files/edge-case-folders-are-missing.test.js
+++ b/tests/migration/ember-addon/steps/move-test-app-files/edge-case-folders-are-missing.test.js
@@ -1,0 +1,22 @@
+import { moveTestAppFiles } from '../../../../../src/migration/ember-addon/steps/move-test-app-files.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/typescript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | move-test-app-files > edge case (folders are missing)', function () {
+  const inputProject = {};
+
+  const outputProject = {};
+
+  loadFixture(inputProject, options);
+
+  moveTestAppFiles(augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/move-test-app-files/javascript.test.js
+++ b/tests/migration/ember-addon/steps/move-test-app-files/javascript.test.js
@@ -1,0 +1,152 @@
+import { moveTestAppFiles } from '../../../../../src/migration/ember-addon/steps/move-test-app-files.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/javascript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | move-test-app-files > javascript', function () {
+  const inputProject = {
+    tests: {
+      acceptance: {
+        album: {
+          'accessibility-test.js': '',
+          'visual-regression-test.js': '',
+        },
+      },
+      dummy: {
+        app: {
+          components: {
+            '.gitkeep': '',
+          },
+          routes: {
+            '.gitkeep': '',
+          },
+          templates: {
+            '.gitkeep': '',
+          },
+          'app.js': '',
+          'index.html': '',
+          'router.js': '',
+        },
+        config: {
+          'ember-cli-update.json': '',
+          'ember-try.js': '',
+          'environment.js': '',
+          'optional-features.json': '',
+          'targets.js': '',
+        },
+        public: {
+          assets: {
+            'favicon.png': '',
+          },
+          'robots.txt': '',
+        },
+      },
+      helpers: {
+        'index.js': '',
+      },
+      integration: {
+        components: {
+          'container-query': {
+            'dataAttributePrefix-test.js': '',
+            'debounce-test.js': '',
+            'features-test.js': '',
+            'splattributes-test.js': '',
+            'tagName-test.js': '',
+          },
+        },
+      },
+      unit: {
+        utils: {
+          components: {
+            widgets: {
+              'widget-2-test.js': '',
+              'widget-3-test.js': '',
+            },
+          },
+        },
+        '.gitkeep': '',
+      },
+      'index.html': '',
+      'test-helper.js': '',
+    },
+  };
+
+  const outputProject = {
+    'test-app': {
+      app: {
+        components: {
+          '.gitkeep': '',
+        },
+        routes: {
+          '.gitkeep': '',
+        },
+        templates: {
+          '.gitkeep': '',
+        },
+        'app.js': '',
+        'index.html': '',
+        'router.js': '',
+      },
+      config: {
+        'ember-cli-update.json': '',
+        'ember-try.js': '',
+        'environment.js': '',
+        'optional-features.json': '',
+        'targets.js': '',
+      },
+      public: {
+        assets: {
+          'favicon.png': '',
+        },
+        'robots.txt': '',
+      },
+      tests: {
+        acceptance: {
+          album: {
+            'accessibility-test.js': '',
+            'visual-regression-test.js': '',
+          },
+        },
+        helpers: {
+          'index.js': '',
+        },
+        integration: {
+          components: {
+            'container-query': {
+              'dataAttributePrefix-test.js': '',
+              'debounce-test.js': '',
+              'features-test.js': '',
+              'splattributes-test.js': '',
+              'tagName-test.js': '',
+            },
+          },
+        },
+        unit: {
+          utils: {
+            components: {
+              widgets: {
+                'widget-2-test.js': '',
+                'widget-3-test.js': '',
+              },
+            },
+          },
+          '.gitkeep': '',
+        },
+        'index.html': '',
+        'test-helper.js': '',
+      },
+    },
+  };
+
+  loadFixture(inputProject, options);
+
+  moveTestAppFiles(augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/move-test-app-files/typescript.test.js
+++ b/tests/migration/ember-addon/steps/move-test-app-files/typescript.test.js
@@ -1,0 +1,170 @@
+import { moveTestAppFiles } from '../../../../../src/migration/ember-addon/steps/move-test-app-files.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/typescript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+test('migration | ember-addon | steps | move-test-app-files > typescript', function () {
+  const inputProject = {
+    tests: {
+      acceptance: {
+        album: {
+          'accessibility-test.ts': '',
+          'visual-regression-test.ts': '',
+        },
+      },
+      dummy: {
+        app: {
+          components: {
+            '.gitkeep': '',
+          },
+          config: {
+            'environment.d.ts': '',
+          },
+          routes: {
+            '.gitkeep': '',
+          },
+          templates: {
+            '.gitkeep': '',
+          },
+          'app.ts': '',
+          'index.html': '',
+          'router.ts': '',
+        },
+        config: {
+          'ember-cli-update.json': '',
+          'ember-try.js': '',
+          'environment.js': '',
+          'optional-features.json': '',
+          'targets.js': '',
+        },
+        public: {
+          assets: {
+            'favicon.png': '',
+          },
+          'robots.txt': '',
+        },
+      },
+      helpers: {
+        'index.ts': '',
+      },
+      integration: {
+        components: {
+          'container-query': {
+            'dataAttributePrefix-test.ts': '',
+            'debounce-test.ts': '',
+            'features-test.ts': '',
+            'splattributes-test.ts': '',
+            'tagName-test.ts': '',
+          },
+        },
+      },
+      unit: {
+        utils: {
+          components: {
+            widgets: {
+              'widget-2-test.ts': '',
+              'widget-3-test.ts': '',
+            },
+          },
+        },
+        '.gitkeep': '',
+      },
+      'index.html': '',
+      'test-helper.ts': '',
+    },
+    types: {
+      dummy: {
+        'index.d.ts': '',
+      },
+      'global.d.ts': '',
+    },
+  };
+
+  const outputProject = {
+    'test-app': {
+      app: {
+        components: {
+          '.gitkeep': '',
+        },
+        config: {
+          'environment.d.ts': '',
+        },
+        routes: {
+          '.gitkeep': '',
+        },
+        templates: {
+          '.gitkeep': '',
+        },
+        'app.ts': '',
+        'index.html': '',
+        'router.ts': '',
+      },
+      config: {
+        'ember-cli-update.json': '',
+        'ember-try.js': '',
+        'environment.js': '',
+        'optional-features.json': '',
+        'targets.js': '',
+      },
+      public: {
+        assets: {
+          'favicon.png': '',
+        },
+        'robots.txt': '',
+      },
+      tests: {
+        acceptance: {
+          album: {
+            'accessibility-test.ts': '',
+            'visual-regression-test.ts': '',
+          },
+        },
+        helpers: {
+          'index.ts': '',
+        },
+        integration: {
+          components: {
+            'container-query': {
+              'dataAttributePrefix-test.ts': '',
+              'debounce-test.ts': '',
+              'features-test.ts': '',
+              'splattributes-test.ts': '',
+              'tagName-test.ts': '',
+            },
+          },
+        },
+        unit: {
+          utils: {
+            components: {
+              widgets: {
+                'widget-2-test.ts': '',
+                'widget-3-test.ts': '',
+              },
+            },
+          },
+          '.gitkeep': '',
+        },
+        'index.html': '',
+        'test-helper.ts': '',
+      },
+      types: {
+        'test-app': {
+          'index.d.ts': '',
+        },
+        'global.d.ts': '',
+      },
+    },
+  };
+
+  loadFixture(inputProject, options);
+
+  moveTestAppFiles(augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/use-relative-paths/customizations.test.js
+++ b/tests/migration/ember-addon/steps/use-relative-paths/customizations.test.js
@@ -1,4 +1,5 @@
 import { useRelativePaths } from '../../../../../src/migration/ember-addon/steps/use-relative-paths.js';
+import { convertToJson } from '../../../../helpers/fixture.js';
 import {
   augmentedOptions,
   options,
@@ -9,135 +10,14 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-const fileMapping = new Map([
-  [
-    'addon/components/container-query.ts',
-    {
-      input: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type {`,
-        `  Dimensions,`,
-        `  Features,`,
-        `  IndexSignatureParameter,`,
-        `  QueryResults,`,
-        `} from 'ember-container-query/modifiers/container-query';`,
-      ].join('\n'),
-
-      output: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type {`,
-        `  Dimensions,`,
-        `  Features,`,
-        `  IndexSignatureParameter,`,
-        `  QueryResults,`,
-        `} from '../modifiers/container-query';`,
-      ].join('\n'),
-    },
-  ],
-
-  [
-    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts',
-    {
-      input: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type { Image } from 'dummy/data/concert';`,
-        `import { findBestFittingImage } from 'dummy/utils/components/widgets/widget-3';`,
-        `import type { Dimensions } from 'ember-container-query/modifiers/container-query';`,
-      ].join('\n'),
-
-      output: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type { Image } from '../../../../data/concert';`,
-        `import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';`,
-        `import type { Dimensions } from 'ember-container-query/modifiers/container-query';`,
-      ].join('\n'),
-    },
-  ],
-
-  [
-    'tests/dummy/app/app.ts',
-    {
-      input: [
-        `import Application from '@ember/application';`,
-        `import config from 'dummy/config/environment';`,
-        `import loadInitializers from 'ember-load-initializers';`,
-        `import Resolver from 'ember-resolver';`,
-      ].join('\n'),
-
-      output: [
-        `import Application from '@ember/application';`,
-        `import config from './config/environment';`,
-        `import loadInitializers from 'ember-load-initializers';`,
-        `import Resolver from 'ember-resolver';`,
-      ].join('\n'),
-    },
-  ],
-]);
-
 test('migration | ember-addon | steps | use-relative-paths > customizations', function () {
-  const inputProject = {
-    addon: {
-      components: {
-        'container-query.ts': fileMapping.get(
-          'addon/components/container-query.ts'
-        ).input,
-      },
-    },
-    tests: {
-      dummy: {
-        app: {
-          components: {
-            widgets: {
-              'widget-3': {
-                'tour-schedule': {
-                  'responsive-image.ts': fileMapping.get(
-                    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts'
-                  ).input,
-                },
-              },
-            },
-          },
-          'app.ts': fileMapping.get('tests/dummy/app/app.ts').input,
-        },
-      },
-    },
-  };
+  const inputProject = convertToJson(
+    'steps/use-relative-paths/customizations/input'
+  );
 
-  const outputProject = {
-    addon: {
-      components: {
-        'container-query.ts': fileMapping.get(
-          'addon/components/container-query.ts'
-        ).output,
-      },
-    },
-    tests: {
-      dummy: {
-        app: {
-          components: {
-            widgets: {
-              'widget-3': {
-                'tour-schedule': {
-                  'responsive-image.ts': fileMapping.get(
-                    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts'
-                  ).output,
-                },
-              },
-            },
-          },
-          'app.ts': fileMapping.get('tests/dummy/app/app.ts').output,
-        },
-      },
-    },
-  };
+  const outputProject = convertToJson(
+    'steps/use-relative-paths/customizations/output'
+  );
 
   loadFixture(inputProject, options);
 

--- a/tests/migration/ember-addon/steps/use-relative-paths/idempotency.test.js
+++ b/tests/migration/ember-addon/steps/use-relative-paths/idempotency.test.js
@@ -1,4 +1,5 @@
 import { useRelativePaths } from '../../../../../src/migration/ember-addon/steps/use-relative-paths.js';
+import { convertToJson } from '../../../../helpers/fixture.js';
 import {
   augmentedOptions,
   options,
@@ -9,135 +10,14 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-const fileMapping = new Map([
-  [
-    'addon/components/container-query.ts',
-    {
-      input: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type {`,
-        `  Dimensions,`,
-        `  Features,`,
-        `  IndexSignatureParameter,`,
-        `  QueryResults,`,
-        `} from '../modifiers/container-query';`,
-      ].join('\n'),
-
-      output: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type {`,
-        `  Dimensions,`,
-        `  Features,`,
-        `  IndexSignatureParameter,`,
-        `  QueryResults,`,
-        `} from '../modifiers/container-query';`,
-      ].join('\n'),
-    },
-  ],
-
-  [
-    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts',
-    {
-      input: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type { Image } from '../../../../data/concert';`,
-        `import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';`,
-        `import type { Dimensions } from 'ember-container-query/modifiers/container-query';`,
-      ].join('\n'),
-
-      output: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type { Image } from '../../../../data/concert';`,
-        `import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';`,
-        `import type { Dimensions } from 'ember-container-query/modifiers/container-query';`,
-      ].join('\n'),
-    },
-  ],
-
-  [
-    'tests/dummy/app/app.ts',
-    {
-      input: [
-        `import Application from '@ember/application';`,
-        `import config from './config/environment';`,
-        `import loadInitializers from 'ember-load-initializers';`,
-        `import Resolver from 'ember-resolver';`,
-      ].join('\n'),
-
-      output: [
-        `import Application from '@ember/application';`,
-        `import config from './config/environment';`,
-        `import loadInitializers from 'ember-load-initializers';`,
-        `import Resolver from 'ember-resolver';`,
-      ].join('\n'),
-    },
-  ],
-]);
-
 test('migration | ember-addon | steps | use-relative-paths > idempotency', function () {
-  const inputProject = {
-    addon: {
-      components: {
-        'container-query.ts': fileMapping.get(
-          'addon/components/container-query.ts'
-        ).input,
-      },
-    },
-    tests: {
-      dummy: {
-        app: {
-          components: {
-            widgets: {
-              'widget-3': {
-                'tour-schedule': {
-                  'responsive-image.ts': fileMapping.get(
-                    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts'
-                  ).input,
-                },
-              },
-            },
-          },
-          'app.ts': fileMapping.get('tests/dummy/app/app.ts').input,
-        },
-      },
-    },
-  };
+  const inputProject = convertToJson(
+    'steps/use-relative-paths/typescript/output'
+  );
 
-  const outputProject = {
-    addon: {
-      components: {
-        'container-query.ts': fileMapping.get(
-          'addon/components/container-query.ts'
-        ).output,
-      },
-    },
-    tests: {
-      dummy: {
-        app: {
-          components: {
-            widgets: {
-              'widget-3': {
-                'tour-schedule': {
-                  'responsive-image.ts': fileMapping.get(
-                    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts'
-                  ).output,
-                },
-              },
-            },
-          },
-          'app.ts': fileMapping.get('tests/dummy/app/app.ts').output,
-        },
-      },
-    },
-  };
+  const outputProject = convertToJson(
+    'steps/use-relative-paths/typescript/output'
+  );
 
   loadFixture(inputProject, options);
 

--- a/tests/migration/ember-addon/steps/use-relative-paths/idempotency.test.js
+++ b/tests/migration/ember-addon/steps/use-relative-paths/idempotency.test.js
@@ -1,0 +1,147 @@
+import { useRelativePaths } from '../../../../../src/migration/ember-addon/steps/use-relative-paths.js';
+import {
+  augmentedOptions,
+  options,
+} from '../../../../helpers/shared-test-setups/typescript.js';
+import {
+  assertFixture,
+  loadFixture,
+  test,
+} from '../../../../helpers/testing.js';
+
+const fileMapping = new Map([
+  [
+    'addon/components/container-query.ts',
+    {
+      input: [
+        `import { action } from '@ember/object';`,
+        `import Component from '@glimmer/component';`,
+        `import { tracked } from '@glimmer/tracking';`,
+        `import type {`,
+        `  Dimensions,`,
+        `  Features,`,
+        `  IndexSignatureParameter,`,
+        `  QueryResults,`,
+        `} from '../modifiers/container-query';`,
+      ].join('\n'),
+
+      output: [
+        `import { action } from '@ember/object';`,
+        `import Component from '@glimmer/component';`,
+        `import { tracked } from '@glimmer/tracking';`,
+        `import type {`,
+        `  Dimensions,`,
+        `  Features,`,
+        `  IndexSignatureParameter,`,
+        `  QueryResults,`,
+        `} from '../modifiers/container-query';`,
+      ].join('\n'),
+    },
+  ],
+
+  [
+    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts',
+    {
+      input: [
+        `import { action } from '@ember/object';`,
+        `import Component from '@glimmer/component';`,
+        `import { tracked } from '@glimmer/tracking';`,
+        `import type { Image } from '../../../../data/concert';`,
+        `import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';`,
+        `import type { Dimensions } from 'ember-container-query/modifiers/container-query';`,
+      ].join('\n'),
+
+      output: [
+        `import { action } from '@ember/object';`,
+        `import Component from '@glimmer/component';`,
+        `import { tracked } from '@glimmer/tracking';`,
+        `import type { Image } from '../../../../data/concert';`,
+        `import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';`,
+        `import type { Dimensions } from 'ember-container-query/modifiers/container-query';`,
+      ].join('\n'),
+    },
+  ],
+
+  [
+    'tests/dummy/app/app.ts',
+    {
+      input: [
+        `import Application from '@ember/application';`,
+        `import config from './config/environment';`,
+        `import loadInitializers from 'ember-load-initializers';`,
+        `import Resolver from 'ember-resolver';`,
+      ].join('\n'),
+
+      output: [
+        `import Application from '@ember/application';`,
+        `import config from './config/environment';`,
+        `import loadInitializers from 'ember-load-initializers';`,
+        `import Resolver from 'ember-resolver';`,
+      ].join('\n'),
+    },
+  ],
+]);
+
+test('migration | ember-addon | steps | use-relative-paths > idempotency', function () {
+  const inputProject = {
+    addon: {
+      components: {
+        'container-query.ts': fileMapping.get(
+          'addon/components/container-query.ts'
+        ).input,
+      },
+    },
+    tests: {
+      dummy: {
+        app: {
+          components: {
+            widgets: {
+              'widget-3': {
+                'tour-schedule': {
+                  'responsive-image.ts': fileMapping.get(
+                    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts'
+                  ).input,
+                },
+              },
+            },
+          },
+          'app.ts': fileMapping.get('tests/dummy/app/app.ts').input,
+        },
+      },
+    },
+  };
+
+  const outputProject = {
+    addon: {
+      components: {
+        'container-query.ts': fileMapping.get(
+          'addon/components/container-query.ts'
+        ).output,
+      },
+    },
+    tests: {
+      dummy: {
+        app: {
+          components: {
+            widgets: {
+              'widget-3': {
+                'tour-schedule': {
+                  'responsive-image.ts': fileMapping.get(
+                    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts'
+                  ).output,
+                },
+              },
+            },
+          },
+          'app.ts': fileMapping.get('tests/dummy/app/app.ts').output,
+        },
+      },
+    },
+  };
+
+  loadFixture(inputProject, options);
+
+  useRelativePaths(augmentedOptions);
+
+  assertFixture(outputProject, options);
+});

--- a/tests/migration/ember-addon/steps/use-relative-paths/javascript.test.js
+++ b/tests/migration/ember-addon/steps/use-relative-paths/javascript.test.js
@@ -1,4 +1,5 @@
 import { useRelativePaths } from '../../../../../src/migration/ember-addon/steps/use-relative-paths.js';
+import { convertToJson } from '../../../../helpers/fixture.js';
 import {
   augmentedOptions,
   options,
@@ -9,119 +10,14 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-const fileMapping = new Map([
-  [
-    'addon/components/container-query.js',
-    {
-      input: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-      ].join('\n'),
-
-      output: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-      ].join('\n'),
-    },
-  ],
-
-  [
-    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.js',
-    {
-      input: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import { findBestFittingImage } from 'dummy/utils/components/widgets/widget-3';`,
-      ].join('\n'),
-
-      output: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';`,
-      ].join('\n'),
-    },
-  ],
-
-  [
-    'tests/dummy/app/app.js',
-    {
-      input: [
-        `import Application from '@ember/application';`,
-        `import config from 'dummy/config/environment';`,
-        `import loadInitializers from 'ember-load-initializers';`,
-        `import Resolver from 'ember-resolver';`,
-      ].join('\n'),
-
-      output: [
-        `import Application from '@ember/application';`,
-        `import config from './config/environment';`,
-        `import loadInitializers from 'ember-load-initializers';`,
-        `import Resolver from 'ember-resolver';`,
-      ].join('\n'),
-    },
-  ],
-]);
-
 test('migration | ember-addon | steps | use-relative-paths > typescript', function () {
-  const inputProject = {
-    addon: {
-      components: {
-        'container-query.js': fileMapping.get(
-          'addon/components/container-query.js'
-        ).input,
-      },
-    },
-    tests: {
-      dummy: {
-        app: {
-          components: {
-            widgets: {
-              'widget-3': {
-                'tour-schedule': {
-                  'responsive-image.js': fileMapping.get(
-                    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.js'
-                  ).input,
-                },
-              },
-            },
-          },
-          'app.js': fileMapping.get('tests/dummy/app/app.js').input,
-        },
-      },
-    },
-  };
+  const inputProject = convertToJson(
+    'steps/use-relative-paths/javascript/input'
+  );
 
-  const outputProject = {
-    addon: {
-      components: {
-        'container-query.js': fileMapping.get(
-          'addon/components/container-query.js'
-        ).output,
-      },
-    },
-    tests: {
-      dummy: {
-        app: {
-          components: {
-            widgets: {
-              'widget-3': {
-                'tour-schedule': {
-                  'responsive-image.js': fileMapping.get(
-                    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.js'
-                  ).output,
-                },
-              },
-            },
-          },
-          'app.js': fileMapping.get('tests/dummy/app/app.js').output,
-        },
-      },
-    },
-  };
+  const outputProject = convertToJson(
+    'steps/use-relative-paths/javascript/output'
+  );
 
   loadFixture(inputProject, options);
 

--- a/tests/migration/ember-addon/steps/use-relative-paths/typescript.test.js
+++ b/tests/migration/ember-addon/steps/use-relative-paths/typescript.test.js
@@ -1,4 +1,5 @@
 import { useRelativePaths } from '../../../../../src/migration/ember-addon/steps/use-relative-paths.js';
+import { convertToJson } from '../../../../helpers/fixture.js';
 import {
   augmentedOptions,
   options,
@@ -9,135 +10,14 @@ import {
   test,
 } from '../../../../helpers/testing.js';
 
-const fileMapping = new Map([
-  [
-    'addon/components/container-query.ts',
-    {
-      input: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type {`,
-        `  Dimensions,`,
-        `  Features,`,
-        `  IndexSignatureParameter,`,
-        `  QueryResults,`,
-        `} from 'ember-container-query/modifiers/container-query';`,
-      ].join('\n'),
-
-      output: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type {`,
-        `  Dimensions,`,
-        `  Features,`,
-        `  IndexSignatureParameter,`,
-        `  QueryResults,`,
-        `} from '../modifiers/container-query';`,
-      ].join('\n'),
-    },
-  ],
-
-  [
-    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts',
-    {
-      input: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type { Image } from 'dummy/data/concert';`,
-        `import { findBestFittingImage } from 'dummy/utils/components/widgets/widget-3';`,
-        `import type { Dimensions } from 'ember-container-query/modifiers/container-query';`,
-      ].join('\n'),
-
-      output: [
-        `import { action } from '@ember/object';`,
-        `import Component from '@glimmer/component';`,
-        `import { tracked } from '@glimmer/tracking';`,
-        `import type { Image } from '../../../../data/concert';`,
-        `import { findBestFittingImage } from '../../../../utils/components/widgets/widget-3';`,
-        `import type { Dimensions } from 'ember-container-query/modifiers/container-query';`,
-      ].join('\n'),
-    },
-  ],
-
-  [
-    'tests/dummy/app/app.ts',
-    {
-      input: [
-        `import Application from '@ember/application';`,
-        `import config from 'dummy/config/environment';`,
-        `import loadInitializers from 'ember-load-initializers';`,
-        `import Resolver from 'ember-resolver';`,
-      ].join('\n'),
-
-      output: [
-        `import Application from '@ember/application';`,
-        `import config from './config/environment';`,
-        `import loadInitializers from 'ember-load-initializers';`,
-        `import Resolver from 'ember-resolver';`,
-      ].join('\n'),
-    },
-  ],
-]);
-
 test('migration | ember-addon | steps | use-relative-paths > typescript', function () {
-  const inputProject = {
-    addon: {
-      components: {
-        'container-query.ts': fileMapping.get(
-          'addon/components/container-query.ts'
-        ).input,
-      },
-    },
-    tests: {
-      dummy: {
-        app: {
-          components: {
-            widgets: {
-              'widget-3': {
-                'tour-schedule': {
-                  'responsive-image.ts': fileMapping.get(
-                    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts'
-                  ).input,
-                },
-              },
-            },
-          },
-          'app.ts': fileMapping.get('tests/dummy/app/app.ts').input,
-        },
-      },
-    },
-  };
+  const inputProject = convertToJson(
+    'steps/use-relative-paths/typescript/input'
+  );
 
-  const outputProject = {
-    addon: {
-      components: {
-        'container-query.ts': fileMapping.get(
-          'addon/components/container-query.ts'
-        ).output,
-      },
-    },
-    tests: {
-      dummy: {
-        app: {
-          components: {
-            widgets: {
-              'widget-3': {
-                'tour-schedule': {
-                  'responsive-image.ts': fileMapping.get(
-                    'tests/dummy/app/components/widgets/widget-3/tour-schedule/responsive-image.ts'
-                  ).output,
-                },
-              },
-            },
-          },
-          'app.ts': fileMapping.get('tests/dummy/app/app.ts').output,
-        },
-      },
-    },
-  };
+  const outputProject = convertToJson(
+    'steps/use-relative-paths/typescript/output'
+  );
 
   loadFixture(inputProject, options);
 


### PR DESCRIPTION
## Description

I added tests for the following steps:

- `moveTestAppFiles`
- `moveProjectRootFiles`
- `createFilesFromBlueprint`

In addition, I created test fixtures to thoroughly (and more easily) test `useRelativePaths` and `createFilesFromBlueprint`. For `createFilesFromBlueprint`, where we use [evaluations](https://github.com/ijlee2/ember-codemod-v1-to-v2/blob/0.1.3/src/utils/process-template.js#L7) and [interpolations](https://github.com/ijlee2/ember-codemod-v1-to-v2/blob/0.1.3/src/utils/process-template.js#L8) to dynamically create files, it's important that we check the file content under various conditions. Note how, in commit 10, we could catch and remove the extra new lines that had been added to `_addonLocation__/unpublished-development-types/index.d.ts` by mistake.

By laying the foundation for testing a step against test fixtures, we will be able to rigorously test `updateAddonPackageJson`, `updateAddonTsconfigJson`, `updateTestAppPackageJson`, and `updateTestAppTsconfigJson` in the next pull request.