### PR TITLE
Updated latestVersions and refactored code

### DIFF
--- a/src/utils/blueprints/decide-version.js
+++ b/src/utils/blueprints/decide-version.js
@@ -1,19 +1,19 @@
 const latestVersions = new Map([
   ['@babel/core', '7.20.12'],
   ['@babel/plugin-proposal-class-properties', '7.18.6'],
-  ['@babel/plugin-proposal-decorators', '7.20.7'],
+  ['@babel/plugin-proposal-decorators', '7.20.13'],
   ['@babel/preset-typescript', '7.18.6'],
   ['@embroider/addon-dev', '3.0.0'],
   ['@embroider/addon-shim', '1.8.4'],
   ['@rollup/plugin-babel', '6.0.3'],
   ['concurrently', '7.6.0'],
-  ['ember-auto-import', '2.5.0'],
+  ['ember-auto-import', '2.6.0'],
   ['ember-cli-babel', '7.26.11'],
-  ['ember-cli-htmlbars', '6.1.11'],
+  ['ember-cli-htmlbars', '6.2.0'],
   ['prettier', '2.8.3'],
-  ['rollup', '3.10.0'],
+  ['rollup', '3.12.0'],
   ['rollup-plugin-copy', '3.4.0'],
-  ['rollup-plugin-ts', '3.1.1'],
+  ['rollup-plugin-ts', '3.2.0'],
 ]);
 
 export function decideVersion(packageName, options) {

--- a/src/utils/blueprints/decide-version.js
+++ b/src/utils/blueprints/decide-version.js
@@ -20,7 +20,18 @@ export function decideVersion(packageName, options) {
   const { packages } = options;
 
   const installedVersion = packages.addon.dependencies.get(packageName);
-  const latestVersion = `^${latestVersions.get(packageName)}`;
 
-  return installedVersion ?? latestVersion;
+  if (installedVersion) {
+    return installedVersion;
+  }
+
+  const latestVersion = latestVersions.get(packageName);
+
+  if (!latestVersion) {
+    throw new RangeError(
+      `ERROR: The latest version of \`${packageName}\` is unknown.\n`
+    );
+  }
+
+  return `^${latestVersion}`;
 }

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
@@ -65,12 +65,12 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@babel/preset-typescript": "^7.18.6",
     "@embroider/addon-dev": "^3.0.0",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-ts": "^3.1.1"
+    "rollup-plugin-ts": "^3.2.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
@@ -65,12 +65,12 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@babel/preset-typescript": "^7.18.6",
     "@embroider/addon-dev": "^3.0.0",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-ts": "^3.1.1"
+    "rollup-plugin-ts": "^3.2.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
@@ -65,7 +65,7 @@
     "@babel/plugin-proposal-decorators": "^7.20.7",
     "@embroider/addon-dev": "^3.0.0",
     "@rollup/plugin-babel": "^6.0.3",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
@@ -65,12 +65,12 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@babel/preset-typescript": "^7.18.6",
     "@embroider/addon-dev": "^3.0.0",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-ts": "^3.1.1"
+    "rollup-plugin-ts": "^3.2.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
@@ -35,12 +35,12 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@babel/preset-typescript": "^7.18.6",
     "@embroider/addon-dev": "^3.0.0",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-ts": "^3.1.1"
+    "rollup-plugin-ts": "^3.2.0"
   },
   "peerDependencies": {
     "ember-source": "^3.28.0 || ^4.0.0"

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
@@ -32,10 +32,10 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@embroider/addon-dev": "^3.0.0",
     "@rollup/plugin-babel": "^6.0.3",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
@@ -32,10 +32,10 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@embroider/addon-dev": "^3.0.0",
     "@rollup/plugin-babel": "^6.0.3",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
@@ -32,10 +32,10 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@embroider/addon-dev": "^3.0.0",
     "@rollup/plugin-babel": "^6.0.3",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
@@ -35,12 +35,12 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@babel/preset-typescript": "^7.18.6",
     "@embroider/addon-dev": "^3.0.0",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-ts": "^3.1.1"
+    "rollup-plugin-ts": "^3.2.0"
   },
   "peerDependencies": {
     "ember-source": "^3.28.0 || ^4.0.0"

--- a/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
@@ -65,12 +65,12 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@babel/preset-typescript": "^7.18.6",
     "@embroider/addon-dev": "^3.0.0",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-ts": "^3.1.1"
+    "rollup-plugin-ts": "^3.2.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
@@ -65,12 +65,12 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@babel/preset-typescript": "^7.18.6",
     "@embroider/addon-dev": "^3.0.0",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-ts": "^3.1.1"
+    "rollup-plugin-ts": "^3.2.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
@@ -65,7 +65,7 @@
     "@babel/plugin-proposal-decorators": "^7.20.7",
     "@embroider/addon-dev": "^3.0.0",
     "@rollup/plugin-babel": "^6.0.3",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
@@ -65,12 +65,12 @@
   "devDependencies": {
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-proposal-decorators": "^7.20.13",
     "@babel/preset-typescript": "^7.18.6",
     "@embroider/addon-dev": "^3.0.0",
-    "rollup": "^3.10.0",
+    "rollup": "^3.12.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-ts": "^3.1.1"
+    "rollup-plugin-ts": "^3.2.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/utils/blueprints/decide-version.test.js
+++ b/tests/utils/blueprints/decide-version.test.js
@@ -8,8 +8,24 @@ test('utils | blueprints | decide-version > package is installed', function () {
   assert.strictEqual(version, '^2.8.1');
 });
 
-test('utils | blueprints | decide-version > package is not installed', function () {
+test('utils | blueprints | decide-version > package is not installed and we provide the latest version', function () {
   const version = decideVersion('rollup', options);
 
   assert.strictEqual(version, '^3.12.0');
+});
+
+test('utils | blueprints | decide-version > package is not installed and we forgot to provide the latest version', function () {
+  assert.throws(
+    () => {
+      decideVersion('some-package-not-part-of-blueprint', options);
+    },
+    (error) => {
+      assert.strictEqual(
+        error.message,
+        'ERROR: The latest version of `some-package-not-part-of-blueprint` is unknown.\n'
+      );
+
+      return true;
+    }
+  );
 });

--- a/tests/utils/blueprints/decide-version.test.js
+++ b/tests/utils/blueprints/decide-version.test.js
@@ -11,5 +11,5 @@ test('utils | blueprints | decide-version > package is installed', function () {
 test('utils | blueprints | decide-version > package is not installed', function () {
   const version = decideVersion('rollup', options);
 
-  assert.strictEqual(version, '^3.10.0');
+  assert.strictEqual(version, '^3.12.0');
 });


### PR DESCRIPTION
## Background

Rather than having an extra dependency (e.g. [`latest-version`](https://github.com/sindresorhus/latest-version)), this project hardcodes the latest versions. At the moment, there is [a reasonable number of packages](https://github.com/ijlee2/ember-codemod-v1-to-v2/blob/523a2bb48d5976f14d926bba139f238bfd5e323c/src/utils/blueprints/decide-version.js#L1-L17) (15) that `@embroider/addon-blueprint` needs. Most are stable and haven't needed to release a new version in months.


## What changed?

In addition to keeping `latestVersions` up-to-date, I added a `RangeError` to help catch a development mistake early. The error can be thrown only if we forget to add a package (that `@embroider/addon-blueprint` needs) to `latestVersions`.