### PR TITLE
Listed the default condition as the last

### DIFF
--- a/src/migration/ember-addon/steps/update-addon-package-json.js
+++ b/src/migration/ember-addon/steps/update-addon-package-json.js
@@ -90,8 +90,8 @@ function updateOtherFields(packageJson, options) {
     ? {
         '.': './dist/index.js',
         './*': {
-          default: './dist/*.js',
           types: './dist/*.d.ts',
+          default: './dist/*.js',
         },
         './addon-main.js': './addon-main.cjs',
       }

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
@@ -87,8 +87,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./*": {
-      "default": "./dist/*.js",
-      "types": "./dist/*.d.ts"
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     },
     "./addon-main.js": "./addon-main.cjs"
   },

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
@@ -87,8 +87,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./*": {
-      "default": "./dist/*.js",
-      "types": "./dist/*.d.ts"
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     },
     "./addon-main.js": "./addon-main.cjs"
   },

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
@@ -87,8 +87,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./*": {
-      "default": "./dist/*.js",
-      "types": "./dist/*.d.ts"
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     },
     "./addon-main.js": "./addon-main.cjs"
   },

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
@@ -60,8 +60,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./*": {
-      "default": "./dist/*.js",
-      "types": "./dist/*.d.ts"
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     },
     "./addon-main.js": "./addon-main.cjs"
   },

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
@@ -60,8 +60,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./*": {
-      "default": "./dist/*.js",
-      "types": "./dist/*.d.ts"
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     },
     "./addon-main.js": "./addon-main.cjs"
   },

--- a/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
@@ -87,8 +87,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./*": {
-      "default": "./dist/*.js",
-      "types": "./dist/*.d.ts"
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     },
     "./addon-main.js": "./addon-main.cjs"
   },

--- a/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
@@ -87,8 +87,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./*": {
-      "default": "./dist/*.js",
-      "types": "./dist/*.d.ts"
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     },
     "./addon-main.js": "./addon-main.cjs"
   },

--- a/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
@@ -87,8 +87,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./*": {
-      "default": "./dist/*.js",
-      "types": "./dist/*.d.ts"
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
     },
     "./addon-main.js": "./addon-main.cjs"
   },


### PR DESCRIPTION
## Background

While downstreaming the changes from #14 to [`ember-container-query`](https://github.com/ijlee2/ember-container-query/pull/157), I realized that the `default` key _must_ appear as last in the POJO for `'./*'`. Otherwise, when we try to build the `test-app`, we will encounter errors like the one below:

```sh
ERROR in cache-233-webpack_bundler_ember_auto_import_webpack/app.cjs 20:82-141
Module not found: Error: Default condition should be last one
```

It feels counterintuitive (a technical risk) that the keys of an object have an order dependency.