### PR TITLE
Downstreamed changes from @embroider/addon-blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Step 5. Celebrate.
 
 <sup>1. Before running `ember-codemod-v1-to-v2`, consider [meeting the prerequisites](https://github.com/embroider-build/embroider/blob/v1.8.3/PORTING-ADDONS-TO-V2.md#part-3-prerequisites-for-v2-addon). You can run [`ember-codemod-pod-to-octane`](https://github.com/ijlee2/ember-codemod-pod-to-octane) to un-pod a v1 addon.</sup>
 
-<sup>2. Files such as `.eslintrc.js`, `.gitignore`, `babel.config.json` (addon only), `config/environment.js` (test-app only), `ember-cli-build.js` (test-app only), `package.json`, `rollup.config.js` (addon only), `tsconfig.json`, etc.</sup>
+<sup>2. Files such as `.eslintrc.js`, `.gitignore`, `babel.config.json` (addon only), `config/environment.js` (test-app only), `ember-cli-build.js` (test-app only), `package.json`, `rollup.config.mjs` (addon only), `tsconfig.json`, etc.</sup>
 
 
 ### Arguments

--- a/src/blueprints/ember-addon/.prettierignore
+++ b/src/blueprints/ember-addon/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/src/blueprints/ember-addon/__gitignore__
+++ b/src/blueprints/ember-addon/__gitignore__
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/src/blueprints/ember-addon/package.json
+++ b/src/blueprints/ember-addon/package.json
@@ -30,10 +30,6 @@
   "repository": "",
   "license": "MIT",
   "author": "",
-  "workspaces": [
-    "<%= options.locations.addon %>",
-    "<%= options.locations.testApp %>"
-  ],
   "scripts": {
     "build": "pnpm --filter <%= options.packages.addon.name %> build",
     "lint": "pnpm --filter '*' lint",

--- a/tests/fixtures/ember-container-query-customizations/output/.gitignore
+++ b/tests/fixtures/ember-container-query-customizations/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/ember-container-query-customizations/output/.prettierignore
+++ b/tests/fixtures/ember-container-query-customizations/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/ember-container-query-glint/output/.gitignore
+++ b/tests/fixtures/ember-container-query-glint/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/ember-container-query-glint/output/.prettierignore
+++ b/tests/fixtures/ember-container-query-glint/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/ember-container-query-javascript/output/.gitignore
+++ b/tests/fixtures/ember-container-query-javascript/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/ember-container-query-javascript/output/.prettierignore
+++ b/tests/fixtures/ember-container-query-javascript/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/ember-container-query-scoped/output/.gitignore
+++ b/tests/fixtures/ember-container-query-scoped/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/ember-container-query-scoped/output/.prettierignore
+++ b/tests/fixtures/ember-container-query-scoped/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/ember-container-query-typescript/output/.gitignore
+++ b/tests/fixtures/ember-container-query-typescript/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/ember-container-query-typescript/output/.prettierignore
+++ b/tests/fixtures/ember-container-query-typescript/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/new-v1-addon-customizations/output/.gitignore
+++ b/tests/fixtures/new-v1-addon-customizations/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/new-v1-addon-customizations/output/.prettierignore
+++ b/tests/fixtures/new-v1-addon-customizations/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/new-v1-addon-javascript/output/.gitignore
+++ b/tests/fixtures/new-v1-addon-javascript/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/new-v1-addon-javascript/output/.prettierignore
+++ b/tests/fixtures/new-v1-addon-javascript/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/new-v1-addon-npm/output/.gitignore
+++ b/tests/fixtures/new-v1-addon-npm/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/new-v1-addon-npm/output/.prettierignore
+++ b/tests/fixtures/new-v1-addon-npm/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/new-v1-addon-pnpm/output/.gitignore
+++ b/tests/fixtures/new-v1-addon-pnpm/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/new-v1-addon-pnpm/output/.prettierignore
+++ b/tests/fixtures/new-v1-addon-pnpm/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/new-v1-addon-pnpm/output/package.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/package.json
@@ -5,10 +5,6 @@
   "repository": "",
   "license": "MIT",
   "author": "",
-  "workspaces": [
-    "new-v1-addon",
-    "test-app"
-  ],
   "scripts": {
     "build": "pnpm --filter new-v1-addon build",
     "lint": "pnpm --filter '*' lint",

--- a/tests/fixtures/new-v1-addon-typescript/output/.gitignore
+++ b/tests/fixtures/new-v1-addon-typescript/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/new-v1-addon-typescript/output/.prettierignore
+++ b/tests/fixtures/new-v1-addon-typescript/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/package.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/package.json
@@ -5,10 +5,6 @@
   "repository": "",
   "license": "MIT",
   "author": "",
-  "workspaces": [
-    "ember-container-query",
-    "test-app"
-  ],
   "scripts": {
     "build": "pnpm --filter ember-container-query build",
     "lint": "pnpm --filter '*' lint",

--- a/tests/fixtures/steps/create-files-from-blueprint/scoped/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/scoped/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/scoped/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/scoped/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/.gitignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/.gitignore
@@ -1,18 +1,17 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
 
 # dependencies
-/bower_components/
-/node_modules/
+node_modules/
 
 # misc
 /.env*
 /.pnp*
+/.pnpm-debug.log
 /.sass-cache
-/.eslintcache
+.eslintcache
 /connect.lock
 /coverage/
 /libpeerconnection.log
@@ -22,11 +21,5 @@
 
 # ember-try
 /.node_modules.ember-try/
-/bower.json.ember-try
-/npm-shrinkwrap.json.ember-try
 /package.json.ember-try
-/package-lock.json.ember-try
 /yarn.lock.ember-try
-
-# broccoli-debug
-/DEBUG/

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/.prettierignore
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/.prettierignore
@@ -13,8 +13,8 @@
 # misc
 /coverage/
 !.*
-.*/
 .eslintcache
+.lint-todo/
 
 # ember-try
 /.node_modules.ember-try/


### PR DESCRIPTION
## Description

I replicated the changes made in https://github.com/embroider-build/addon-blueprint/pull/106:

- Commits 1-2: For `pnpm` projects, removed the `workspaces` key from `package.json` because it is [unsupported](https://github.com/pnpm/pnpm/issues/2255) (affects the workspace root)
- Commits 3-4: Updated the blueprint files for the root `.gitignore` and `.prettierignore` (affects the workspace root)