### PR TITLE
Wrapped globSync and extracted blueprintRoot

### DIFF
--- a/src/migration/ember-addon/steps/analyze-addon.js
+++ b/src/migration/ember-addon/steps/analyze-addon.js
@@ -30,7 +30,6 @@ function getPublicAssets(options) {
 
   const filePaths = findFiles('public/**/*', {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   return filePaths

--- a/src/migration/ember-addon/steps/analyze-addon.js
+++ b/src/migration/ember-addon/steps/analyze-addon.js
@@ -1,12 +1,10 @@
-import { globSync } from 'glob';
-
 import { decideVersion } from '../../../utils/blueprints.js';
-import { renameDirectory } from '../../../utils/files.js';
+import { findFiles, renameDirectory } from '../../../utils/files.js';
 
 function getAppReexports(options) {
   const { projectRoot } = options;
 
-  const filePaths = globSync('app/**/*.js', {
+  const filePaths = findFiles('app/**/*.js', {
     cwd: projectRoot,
   });
 
@@ -30,10 +28,9 @@ function getProjectRootDevDependencies(options) {
 function getPublicAssets(options) {
   const { projectRoot } = options;
 
-  const filePaths = globSync('public/**/*', {
+  const filePaths = findFiles('public/**/*', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   return filePaths
@@ -49,7 +46,7 @@ function getPublicAssets(options) {
 function getPublicEntrypoints(options) {
   const { projectRoot } = options;
 
-  const filePaths = globSync('{addon,addon-test-support}/**/*.{js,ts}', {
+  const filePaths = findFiles('{addon,addon-test-support}/**/*.{js,ts}', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-addon/steps/create-files-from-blueprint.js
+++ b/src/migration/ember-addon/steps/create-files-from-blueprint.js
@@ -1,18 +1,8 @@
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
-import { processTemplate } from '../../../utils/blueprints.js';
+import { blueprintRoot, processTemplate } from '../../../utils/blueprints.js';
 import { createFiles, findFiles } from '../../../utils/files.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-function getBlueprintRoot() {
-  const codemodRoot = join(__dirname, '../../../..');
-
-  return join(codemodRoot, 'src/blueprints/ember-addon');
-}
 
 function getFilePath(blueprintFilePath, options) {
   const { locations } = options;
@@ -41,8 +31,6 @@ function getFilesToSkip(options) {
 }
 
 export function createFilesFromBlueprint(context, options) {
-  const blueprintRoot = getBlueprintRoot();
-
   const filesToSkip = getFilesToSkip(options);
 
   const blueprintFilePaths = findFiles('**/*', {

--- a/src/migration/ember-addon/steps/create-files-from-blueprint.js
+++ b/src/migration/ember-addon/steps/create-files-from-blueprint.js
@@ -48,7 +48,6 @@ export function createFilesFromBlueprint(context, options) {
   const blueprintFilePaths = findFiles('**/*', {
     cwd: blueprintRoot,
     ignoreList: filesToSkip,
-    matchFilesOnly: true,
   });
 
   const fileMapping = new Map(

--- a/src/migration/ember-addon/steps/create-files-from-blueprint.js
+++ b/src/migration/ember-addon/steps/create-files-from-blueprint.js
@@ -2,10 +2,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { globSync } from 'glob';
-
 import { processTemplate } from '../../../utils/blueprints.js';
-import { createFiles } from '../../../utils/files.js';
+import { createFiles, findFiles } from '../../../utils/files.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -47,11 +45,10 @@ export function createFilesFromBlueprint(context, options) {
 
   const filesToSkip = getFilesToSkip(options);
 
-  const blueprintFilePaths = globSync('**/*', {
+  const blueprintFilePaths = findFiles('**/*', {
     cwd: blueprintRoot,
-    dot: true,
-    ignore: filesToSkip,
-    nodir: true,
+    ignoreList: filesToSkip,
+    matchFilesOnly: true,
   });
 
   const fileMapping = new Map(

--- a/src/migration/ember-addon/steps/create-options.js
+++ b/src/migration/ember-addon/steps/create-options.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { globSync } from 'glob';
+import { findFiles } from '../../../utils/files.js';
 
 function analyzePackageJson(codemodOptions) {
   const { projectRoot } = codemodOptions;
@@ -51,7 +51,7 @@ function analyzePackageJson(codemodOptions) {
 function analyzePackageManager(codemodOptions) {
   const { projectRoot } = codemodOptions;
 
-  const lockFiles = globSync('{package-lock.json,pnpm-lock.yaml,yarn.lock}', {
+  const lockFiles = findFiles('{package-lock.json,pnpm-lock.yaml,yarn.lock}', {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-addon/steps/create-options.js
+++ b/src/migration/ember-addon/steps/create-options.js
@@ -3,6 +3,25 @@ import { join } from 'node:path';
 
 import { findFiles, unionize } from '../../../utils/files.js';
 
+function validatePackageJson({ name, version }) {
+  if (!name) {
+    throw new SyntaxError('Package name is missing.');
+  }
+
+  if (name.includes('/')) {
+    // eslint-disable-next-line no-unused-vars
+    const [_scope, packageName] = name.split('/');
+
+    if (!packageName) {
+      throw new SyntaxError('Package name is missing.');
+    }
+  }
+
+  if (!version) {
+    throw new SyntaxError('Package version is missing.');
+  }
+}
+
 function analyzePackageJson(codemodOptions) {
   const { projectRoot } = codemodOptions;
 
@@ -20,13 +39,7 @@ function analyzePackageJson(codemodOptions) {
       version,
     } = JSON.parse(packageJsonFile);
 
-    if (!name) {
-      throw new SyntaxError('Package name is missing.');
-    }
-
-    if (!version) {
-      throw new SyntaxError('Package version is missing.');
-    }
+    validatePackageJson({ name, version });
 
     const projectDependencies = new Map([
       ...Object.entries(dependencies ?? {}),
@@ -89,13 +102,7 @@ function deriveAddonLocation(addonPackage) {
   }
 
   // eslint-disable-next-line no-unused-vars
-  const [scope, packageName] = addonPackage.name.split('/');
-
-  if (!packageName) {
-    throw new SyntaxError(
-      `ERROR: In package.json, the package name \`${addonPackage.name}\` is not valid.`
-    );
-  }
+  const [_scope, packageName] = addonPackage.name.split('/');
 
   return packageName;
 }

--- a/src/migration/ember-addon/steps/move-addon-files.js
+++ b/src/migration/ember-addon/steps/move-addon-files.js
@@ -1,14 +1,16 @@
-import { globSync } from 'glob';
-
-import { mapFilePaths, moveFiles, removeFiles } from '../../../utils/files.js';
+import {
+  findFiles,
+  mapFilePaths,
+  moveFiles,
+  removeFiles,
+} from '../../../utils/files.js';
 
 function moveAddonFolder(options) {
   const { locations, projectRoot } = options;
 
-  const filePaths = globSync('addon/**/*', {
+  const filePaths = findFiles('addon/**/*', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   const pathMapping = mapFilePaths(filePaths, {
@@ -22,10 +24,9 @@ function moveAddonFolder(options) {
 function moveAddonTestSupportFolder(options) {
   const { locations, projectRoot } = options;
 
-  const filePaths = globSync('addon-test-support/**/*', {
+  const filePaths = findFiles('addon-test-support/**/*', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   const pathMapping = mapFilePaths(filePaths, {
@@ -39,10 +40,9 @@ function moveAddonTestSupportFolder(options) {
 function moveBlueprintsFolder(options) {
   const { locations, projectRoot } = options;
 
-  const filePaths = globSync('blueprints/**/*', {
+  const filePaths = findFiles('blueprints/**/*', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   const pathMapping = mapFilePaths(filePaths, {
@@ -56,10 +56,9 @@ function moveBlueprintsFolder(options) {
 function movePublicFolder(options) {
   const { locations, projectRoot } = options;
 
-  const filePaths = globSync('public/**/*', {
+  const filePaths = findFiles('public/**/*', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   const pathMapping = mapFilePaths(filePaths, {
@@ -73,10 +72,9 @@ function movePublicFolder(options) {
 function removeAppFolder(options) {
   const { projectRoot } = options;
 
-  const filePaths = globSync('app/**/*', {
+  const filePaths = findFiles('app/**/*', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   removeFiles(filePaths, options);

--- a/src/migration/ember-addon/steps/move-addon-files.js
+++ b/src/migration/ember-addon/steps/move-addon-files.js
@@ -10,7 +10,6 @@ function moveAddonFolder(options) {
 
   const filePaths = findFiles('addon/**/*', {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   const pathMapping = mapFilePaths(filePaths, {
@@ -26,7 +25,6 @@ function moveAddonTestSupportFolder(options) {
 
   const filePaths = findFiles('addon-test-support/**/*', {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   const pathMapping = mapFilePaths(filePaths, {
@@ -42,7 +40,6 @@ function moveBlueprintsFolder(options) {
 
   const filePaths = findFiles('blueprints/**/*', {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   const pathMapping = mapFilePaths(filePaths, {
@@ -58,7 +55,6 @@ function movePublicFolder(options) {
 
   const filePaths = findFiles('public/**/*', {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   const pathMapping = mapFilePaths(filePaths, {
@@ -74,7 +70,6 @@ function removeAppFolder(options) {
 
   const filePaths = findFiles('app/**/*', {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   removeFiles(filePaths, options);

--- a/src/migration/ember-addon/steps/move-project-root-files.js
+++ b/src/migration/ember-addon/steps/move-project-root-files.js
@@ -4,22 +4,15 @@ import {
   mapFilePaths,
   moveFiles,
   removeFiles,
+  unionize,
 } from '../../../utils/files.js';
-
-function globPattern(files) {
-  if (files.length <= 1) {
-    return files.join(',');
-  }
-
-  return `{${files.join(',')}}`;
-}
 
 function copyToAddon(options) {
   const { locations, projectRoot } = options;
 
   const files = ['LICENSE.md', 'README.md'];
 
-  const filePaths = findFiles(globPattern(files), {
+  const filePaths = findFiles(unionize(files), {
     cwd: projectRoot,
   });
 
@@ -54,7 +47,7 @@ function moveToAddonAndTestApp(options) {
     files.add('tsconfig.json');
   }
 
-  const filePaths = findFiles(globPattern([...files]), {
+  const filePaths = findFiles(unionize([...files]), {
     cwd: projectRoot,
   });
 
@@ -85,7 +78,7 @@ function moveToTestApp(options) {
     'testem.js',
   ];
 
-  const filePaths = findFiles(globPattern(files), {
+  const filePaths = findFiles(unionize(files), {
     cwd: projectRoot,
   });
 
@@ -102,7 +95,7 @@ function removeFromProjectRoot(options) {
 
   const files = ['.npmignore', 'index.js'];
 
-  const filePaths = findFiles(globPattern(files), {
+  const filePaths = findFiles(unionize(files), {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-addon/steps/move-project-root-files.js
+++ b/src/migration/ember-addon/steps/move-project-root-files.js
@@ -1,7 +1,6 @@
-import { globSync } from 'glob';
-
 import {
   copyFiles,
+  findFiles,
   mapFilePaths,
   moveFiles,
   removeFiles,
@@ -20,7 +19,7 @@ function copyToAddon(options) {
 
   const files = ['LICENSE.md', 'README.md'];
 
-  const filePaths = globSync(globPattern(files), {
+  const filePaths = findFiles(globPattern(files), {
     cwd: projectRoot,
   });
 
@@ -55,7 +54,7 @@ function moveToAddonAndTestApp(options) {
     files.add('tsconfig.json');
   }
 
-  const filePaths = globSync(globPattern([...files]), {
+  const filePaths = findFiles(globPattern([...files]), {
     cwd: projectRoot,
   });
 
@@ -86,7 +85,7 @@ function moveToTestApp(options) {
     'testem.js',
   ];
 
-  const filePaths = globSync(globPattern(files), {
+  const filePaths = findFiles(globPattern(files), {
     cwd: projectRoot,
   });
 
@@ -103,7 +102,7 @@ function removeFromProjectRoot(options) {
 
   const files = ['.npmignore', 'index.js'];
 
-  const filePaths = globSync(globPattern(files), {
+  const filePaths = findFiles(globPattern(files), {
     cwd: projectRoot,
   });
 

--- a/src/migration/ember-addon/steps/move-test-app-files.js
+++ b/src/migration/ember-addon/steps/move-test-app-files.js
@@ -8,7 +8,6 @@ function moveTestsFolder(options) {
 
   let filePaths = findFiles('tests/dummy/**/*', {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   let pathMapping = mapFilePaths(filePaths, {
@@ -21,7 +20,6 @@ function moveTestsFolder(options) {
   filePaths = findFiles('tests/**/*', {
     cwd: projectRoot,
     ignoreList: ['tests/dummy/**/*'],
-    matchFilesOnly: true,
   });
 
   pathMapping = mapFilePaths(filePaths, {
@@ -41,7 +39,6 @@ function moveTypesFolder(options) {
 
   let filePaths = findFiles('types/dummy/**/*', {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   let pathMapping = mapFilePaths(filePaths, {
@@ -54,7 +51,6 @@ function moveTypesFolder(options) {
   filePaths = findFiles('types/**/*', {
     cwd: projectRoot,
     ignoreList: ['types/dummy/**/*'],
-    matchFilesOnly: true,
   });
 
   pathMapping = mapFilePaths(filePaths, {
@@ -72,7 +68,6 @@ function renameDummy(options) {
   // about Ember, and partly to avoid corrupting non-text files
   const filePaths = findFiles(`${locations.testApp}/**/*.{d.ts,html,js,ts}`, {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   filePaths.forEach((filePath) => {

--- a/src/migration/ember-addon/steps/move-test-app-files.js
+++ b/src/migration/ember-addon/steps/move-test-app-files.js
@@ -1,17 +1,14 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { globSync } from 'glob';
-
-import { mapFilePaths, moveFiles } from '../../../utils/files.js';
+import { findFiles, mapFilePaths, moveFiles } from '../../../utils/files.js';
 
 function moveTestsFolder(options) {
   const { locations, projectRoot } = options;
 
-  let filePaths = globSync('tests/dummy/**/*', {
+  let filePaths = findFiles('tests/dummy/**/*', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   let pathMapping = mapFilePaths(filePaths, {
@@ -21,11 +18,10 @@ function moveTestsFolder(options) {
 
   moveFiles(pathMapping, options);
 
-  filePaths = globSync('tests/**/*', {
+  filePaths = findFiles('tests/**/*', {
     cwd: projectRoot,
-    dot: true,
-    ignore: 'tests/dummy/**/*',
-    nodir: true,
+    ignoreList: ['tests/dummy/**/*'],
+    matchFilesOnly: true,
   });
 
   pathMapping = mapFilePaths(filePaths, {
@@ -43,10 +39,9 @@ function moveTypesFolder(options) {
     return;
   }
 
-  let filePaths = globSync('types/dummy/**/*', {
+  let filePaths = findFiles('types/dummy/**/*', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   let pathMapping = mapFilePaths(filePaths, {
@@ -56,11 +51,10 @@ function moveTypesFolder(options) {
 
   moveFiles(pathMapping, options);
 
-  filePaths = globSync('types/**/*', {
+  filePaths = findFiles('types/**/*', {
     cwd: projectRoot,
-    dot: true,
-    ignore: 'types/dummy/**/*',
-    nodir: true,
+    ignoreList: ['types/dummy/**/*'],
+    matchFilesOnly: true,
   });
 
   pathMapping = mapFilePaths(filePaths, {
@@ -76,10 +70,9 @@ function renameDummy(options) {
 
   // File extensions had been specified, partly to encode assumptions
   // about Ember, and partly to avoid corrupting non-text files
-  const filePaths = globSync(`${locations.testApp}/**/*.{d.ts,html,js,ts}`, {
+  const filePaths = findFiles(`${locations.testApp}/**/*.{d.ts,html,js,ts}`, {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   filePaths.forEach((filePath) => {

--- a/src/migration/ember-addon/steps/update-addon-package-json.js
+++ b/src/migration/ember-addon/steps/update-addon-package-json.js
@@ -108,6 +108,9 @@ function updateOtherFields(packageJson, context, options) {
     packageJson['exports'] = {
       '.': './dist/index.js',
       './*': {
+        /*
+          This object has an order dependency. The `default` key must appear last.
+        */
         types: './dist/*.d.ts',
         default: './dist/*.js',
       },

--- a/src/migration/ember-addon/steps/use-relative-paths.js
+++ b/src/migration/ember-addon/steps/use-relative-paths.js
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 
-import { globSync } from 'glob';
+import { findFiles } from '../../../utils/files.js';
 
 function normalizeRelativePath(relativePath) {
   if (!relativePath.startsWith('..')) {
@@ -38,10 +38,9 @@ function useRelativePathInAddonFolder(options) {
 
   // File extensions had been specified, partly to encode assumptions
   // about Ember, and partly to avoid corrupting non-text files
-  const filePaths = globSync('addon/**/*.{d.ts,js,ts}', {
+  const filePaths = findFiles('addon/**/*.{d.ts,js,ts}', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   filePaths.forEach((filePath) => {
@@ -63,10 +62,9 @@ function useRelativePathInTestsDummyFolder(options) {
 
   // File extensions had been specified, partly to encode assumptions
   // about Ember, and partly to avoid corrupting non-text files
-  const filePaths = globSync('tests/dummy/**/*.{d.ts,js,ts}', {
+  const filePaths = findFiles('tests/dummy/**/*.{d.ts,js,ts}', {
     cwd: projectRoot,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   filePaths.forEach((filePath) => {

--- a/src/migration/ember-addon/steps/use-relative-paths.js
+++ b/src/migration/ember-addon/steps/use-relative-paths.js
@@ -40,7 +40,6 @@ function useRelativePathInAddonFolder(options) {
   // about Ember, and partly to avoid corrupting non-text files
   const filePaths = findFiles('addon/**/*.{d.ts,js,ts}', {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   filePaths.forEach((filePath) => {
@@ -64,7 +63,6 @@ function useRelativePathInTestsDummyFolder(options) {
   // about Ember, and partly to avoid corrupting non-text files
   const filePaths = findFiles('tests/dummy/**/*.{d.ts,js,ts}', {
     cwd: projectRoot,
-    matchFilesOnly: true,
   });
 
   filePaths.forEach((filePath) => {

--- a/src/utils/blueprints.js
+++ b/src/utils/blueprints.js
@@ -1,2 +1,3 @@
+export * from './blueprints/blueprint-root.js';
 export * from './blueprints/decide-version.js';
 export * from './blueprints/process-template.js';

--- a/src/utils/blueprints/blueprint-root.js
+++ b/src/utils/blueprints/blueprint-root.js
@@ -1,0 +1,13 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function getBlueprintRoot() {
+  const srcDirectory = join(__dirname, '../..');
+
+  return join(srcDirectory, 'blueprints/ember-addon');
+}
+
+export const blueprintRoot = getBlueprintRoot();

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -1,5 +1,6 @@
 export * from './files/copy-files.js';
 export * from './files/create-files.js';
+export * from './files/find-files.js';
 export * from './files/map-file-paths.js';
 export * from './files/move-files.js';
 export * from './files/remove-directory-if-empty.js';

--- a/src/utils/files/find-files.js
+++ b/src/utils/files/find-files.js
@@ -18,3 +18,11 @@ export function findFiles(pattern, { cwd, ignoreList = [] }) {
 
   return filePaths;
 }
+
+export function unionize(files) {
+  if (files.length <= 1) {
+    return files.join(',');
+  }
+
+  return `{${files.join(',')}}`;
+}

--- a/src/utils/files/find-files.js
+++ b/src/utils/files/find-files.js
@@ -1,6 +1,6 @@
 import { globSync } from 'glob';
 
-export function findFiles(pattern, { cwd, ignoreList = [], matchFilesOnly }) {
+export function findFiles(pattern, { cwd, ignoreList = [] }) {
   if (!pattern) {
     throw new RangeError('ERROR: The glob pattern is unknown.\n');
   }
@@ -9,23 +9,12 @@ export function findFiles(pattern, { cwd, ignoreList = [], matchFilesOnly }) {
     throw new RangeError('ERROR: The current working directory is unknown.\n');
   }
 
-  let options;
-
-  if (matchFilesOnly) {
-    options = {
-      cwd,
-      dot: true,
-      ignore: ignoreList,
-      nodir: true,
-    };
-  } else {
-    options = {
-      cwd,
-      ignore: ignoreList,
-    };
-  }
-
-  const filePaths = globSync(pattern, options);
+  const filePaths = globSync(pattern, {
+    cwd,
+    dot: true,
+    ignore: ignoreList,
+    nodir: true,
+  });
 
   return filePaths;
 }

--- a/src/utils/files/find-files.js
+++ b/src/utils/files/find-files.js
@@ -1,0 +1,31 @@
+import { globSync } from 'glob';
+
+export function findFiles(pattern, { cwd, ignoreList = [], matchFilesOnly }) {
+  if (!pattern) {
+    throw new RangeError('ERROR: The glob pattern is unknown.\n');
+  }
+
+  if (!cwd) {
+    throw new RangeError('ERROR: The current working directory is unknown.\n');
+  }
+
+  let options;
+
+  if (matchFilesOnly) {
+    options = {
+      cwd,
+      dot: true,
+      ignore: ignoreList,
+      nodir: true,
+    };
+  } else {
+    options = {
+      cwd,
+      ignore: ignoreList,
+    };
+  }
+
+  const filePaths = globSync(pattern, options);
+
+  return filePaths;
+}

--- a/tests/helpers/testing/convert-fixture-to-json.js
+++ b/tests/helpers/testing/convert-fixture-to-json.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { globSync } from 'glob';
+import { findFiles } from '../../../src/utils/files.js';
 
 function updateJson(json, { keys, projectRoot }) {
   const key = keys.shift();
@@ -38,10 +38,9 @@ function createJson(filePaths = [], projectRoot) {
 export function convertFixtureToJson(projectRoot) {
   const absolutePath = `${process.cwd()}/tests/fixtures/${projectRoot}`;
 
-  const filePaths = globSync('**/*', {
+  const filePaths = findFiles('**/*', {
     cwd: absolutePath,
-    dot: true,
-    nodir: true,
+    matchFilesOnly: true,
   });
 
   return createJson(filePaths, absolutePath);

--- a/tests/helpers/testing/convert-fixture-to-json.js
+++ b/tests/helpers/testing/convert-fixture-to-json.js
@@ -40,7 +40,6 @@ export function convertFixtureToJson(projectRoot) {
 
   const filePaths = findFiles('**/*', {
     cwd: absolutePath,
-    matchFilesOnly: true,
   });
 
   return createJson(filePaths, absolutePath);

--- a/tests/helpers/testing/convert-fixture-to-json.js
+++ b/tests/helpers/testing/convert-fixture-to-json.js
@@ -3,12 +3,12 @@ import { join } from 'node:path';
 
 import { findFiles } from '../../../src/utils/files.js';
 
-function updateJson(json, { keys, projectRoot }) {
+function updateJson(json, { currentDirectory, keys }) {
   const key = keys.shift();
   const isFile = keys.length === 0;
 
   if (isFile) {
-    json[key] = readFileSync(join(projectRoot, key), 'utf8');
+    json[key] = readFileSync(join(currentDirectory, key), 'utf8');
 
     return;
   }
@@ -18,29 +18,29 @@ function updateJson(json, { keys, projectRoot }) {
   }
 
   updateJson(json[key], {
+    currentDirectory: join(currentDirectory, key),
     keys,
-    projectRoot: join(projectRoot, key),
   });
 }
 
-function createJson(filePaths = [], projectRoot) {
+function createJson(filePaths = [], currentDirectory) {
   const json = {};
 
   filePaths.forEach((filePath) => {
     const keys = filePath.split('/');
 
-    updateJson(json, { keys, projectRoot });
+    updateJson(json, { currentDirectory, keys });
   });
 
   return json;
 }
 
 export function convertFixtureToJson(projectRoot) {
-  const absolutePath = `${process.cwd()}/tests/fixtures/${projectRoot}`;
+  const currentDirectory = `${process.cwd()}/tests/fixtures/${projectRoot}`;
 
   const filePaths = findFiles('**/*', {
-    cwd: absolutePath,
+    cwd: currentDirectory,
   });
 
-  return createJson(filePaths, absolutePath);
+  return createJson(filePaths, currentDirectory);
 }

--- a/tests/migration/ember-addon/steps/create-options/error-handling-package-name-is-not-valid.test.js
+++ b/tests/migration/ember-addon/steps/create-options/error-handling-package-name-is-not-valid.test.js
@@ -24,7 +24,7 @@ test('migration | ember-addon | steps | create-options > error handling (package
     (error) => {
       assert.strictEqual(
         error.message,
-        'ERROR: In package.json, the package name `@ijlee2/` is not valid.'
+        'ERROR: package.json is missing or is not valid. (Package name is missing.)\n'
       );
 
       return true;

--- a/tests/utils/blueprints/blueprint-root.test.js
+++ b/tests/utils/blueprints/blueprint-root.test.js
@@ -1,0 +1,9 @@
+import { blueprintRoot } from '../../../src/utils/blueprints.js';
+import { assert, test } from '../../helpers/testing.js';
+
+test('utils | blueprints | blueprint-root', function () {
+  assert.strictEqual(
+    blueprintRoot.endsWith('src/blueprints/ember-addon'),
+    true
+  );
+});

--- a/tests/utils/files/find-files.test.js
+++ b/tests/utils/files/find-files.test.js
@@ -1,0 +1,57 @@
+import { findFiles } from '../../../src/utils/files.js';
+import { codemodOptions } from '../../helpers/shared-test-setups/typescript.js';
+import { assert, loadFixture, test } from '../../helpers/testing.js';
+
+test('utils | files | find-files', function () {
+  const inputProject = {
+    tests: {
+      dummy: {
+        app: {
+          '.eslintrc.js': '',
+          'app.ts': '',
+          'index.html': '',
+          'router.ts': '',
+        },
+        config: {
+          'environment.js': '',
+          'optional-features.json': '',
+          'targets.js': '',
+        },
+      },
+      integration: {
+        components: {
+          'container-query-test.ts': '',
+        },
+      },
+      'index.html': '',
+      'test-helper.ts': '',
+    },
+    'ember-cli-build.js': '',
+    'index.js': '',
+    'package.json': '',
+  };
+
+  loadFixture(inputProject, codemodOptions);
+
+  let filePaths = findFiles('tests/dummy/**/*.{js,ts}', {
+    cwd: codemodOptions.projectRoot,
+  });
+
+  assert.deepStrictEqual(filePaths.sort(), [
+    'tests/dummy/app/.eslintrc.js',
+    'tests/dummy/app/app.ts',
+    'tests/dummy/app/router.ts',
+    'tests/dummy/config/environment.js',
+    'tests/dummy/config/targets.js',
+  ]);
+
+  filePaths = findFiles('tests/**/*.{js,ts}', {
+    cwd: codemodOptions.projectRoot,
+    ignoreList: ['tests/dummy/**/*'],
+  });
+
+  assert.deepStrictEqual(filePaths.sort(), [
+    'tests/integration/components/container-query-test.ts',
+    'tests/test-helper.ts',
+  ]);
+});


### PR DESCRIPTION
## Background

In #20, updating `glob` from `v8` to `v9`) involved fixing [breaking changes](https://github.com/isaacs/node-glob/blob/v9.2.1/changelog.md#90). Fortunately, the fix wasn't difficult because I had used `glob.sync` (now named `globSync`) in only two (2) different ways.

Nonetheless, `globSync` is used in several files, each with a unique context (i.e. the steps are different from one another). To help onboard new contributors, we should wrap `globSync` and minimize the API that we need.


## What changed?

I took care of a few technical risks:

- Commits 1-3: Created a function called `findFiles`, which wraps `globSync` and minimizes the API.
- Commit 4: Extracted a function called `unionize`, which creates the brace expansion that `glob` understands.
- Commit 5: Extracted a constant called `blueprintRoot`. The value depends on where `npx` installs the codemod on the end-developer's machine.
- Commit 6: Wrote tests for `findFiles` and `blueprintRoot`.
- Commit 7: Separated validation concerns.
- Commit 8: Documented a hidden order dependency.