### PR TITLE
Addressed syntax deprecation from @babel/plugin-proposal-decorators

### DIFF
--- a/src/blueprints/ember-addon/__addonLocation__/babel.config.json
+++ b/src/blueprints/ember-addon/__addonLocation__/babel.config.json
@@ -3,7 +3,7 @@
 <% } %>  "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",<% if (options.packages.addon.hasTypeScript) { %>
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],<% } %>
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/babel.config.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/babel.config.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/babel.config.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/babel.config.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/customizations/output/packages/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/glint/output/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprint/javascript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/javascript/output/ember-container-query/babel.config.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/npm/output/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/pnpm/output/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprint/scoped/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/scoped/output/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprint/typescript/output/ember-container-query/babel.config.json
@@ -3,7 +3,7 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
+    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-proposal-class-properties"
   ]
 }


### PR DESCRIPTION
## Description

According to [Babel](https://babeljs.io/docs/babel-plugin-proposal-decorators#legacy), the syntax `{ "legacy": true }` has been deprecated.

> Use version: "legacy" instead. This option is a legacy alias.

I upstreamed the change in https://github.com/embroider-build/addon-blueprint/pull/127.