### PR TITLE
Replaced assert.deepEqual with assert.deepStrictEqual

### DIFF
--- a/tests/migration/ember-addon/steps/analyze-addon/blueprints.test.js
+++ b/tests/migration/ember-addon/steps/analyze-addon/blueprints.test.js
@@ -27,7 +27,7 @@ test('migration | ember-addon | steps | analyze-addon > blueprints', function ()
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeAddon(options), {
+  assert.deepStrictEqual(analyzeAddon(options), {
     addon: {
       appReexports: [],
       publicAssets: [],

--- a/tests/migration/ember-addon/steps/analyze-addon/customizations.test.js
+++ b/tests/migration/ember-addon/steps/analyze-addon/customizations.test.js
@@ -11,5 +11,5 @@ import {
 test('migration | ember-addon | steps | analyze-addon > customizations', function () {
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeAddon(options), context);
+  assert.deepStrictEqual(analyzeAddon(options), context);
 });

--- a/tests/migration/ember-addon/steps/analyze-addon/edge-case-folders-are-missing.test.js
+++ b/tests/migration/ember-addon/steps/analyze-addon/edge-case-folders-are-missing.test.js
@@ -11,7 +11,7 @@ test('migration | ember-addon | steps | analyze-addon > edge case (folders are m
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeAddon(options), {
+  assert.deepStrictEqual(analyzeAddon(options), {
     addon: {
       appReexports: [],
       publicAssets: [],

--- a/tests/migration/ember-addon/steps/analyze-addon/glint.test.js
+++ b/tests/migration/ember-addon/steps/analyze-addon/glint.test.js
@@ -11,5 +11,5 @@ import {
 test('migration | ember-addon | steps | analyze-addon > glint', function () {
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeAddon(options), context);
+  assert.deepStrictEqual(analyzeAddon(options), context);
 });

--- a/tests/migration/ember-addon/steps/analyze-addon/javascript.test.js
+++ b/tests/migration/ember-addon/steps/analyze-addon/javascript.test.js
@@ -11,5 +11,5 @@ import {
 test('migration | ember-addon | steps | analyze-addon > javascript', function () {
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeAddon(options), context);
+  assert.deepStrictEqual(analyzeAddon(options), context);
 });

--- a/tests/migration/ember-addon/steps/analyze-addon/public-assets.test.js
+++ b/tests/migration/ember-addon/steps/analyze-addon/public-assets.test.js
@@ -24,7 +24,7 @@ test('migration | ember-addon | steps | analyze-addon > public-assets', function
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeAddon(options), {
+  assert.deepStrictEqual(analyzeAddon(options), {
     addon: {
       appReexports: [],
       publicAssets: [

--- a/tests/migration/ember-addon/steps/analyze-addon/scoped.test.js
+++ b/tests/migration/ember-addon/steps/analyze-addon/scoped.test.js
@@ -11,5 +11,5 @@ import {
 test('migration | ember-addon | steps | analyze-addon > scoped', function () {
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeAddon(options), context);
+  assert.deepStrictEqual(analyzeAddon(options), context);
 });

--- a/tests/migration/ember-addon/steps/analyze-addon/test-support.test.js
+++ b/tests/migration/ember-addon/steps/analyze-addon/test-support.test.js
@@ -18,7 +18,7 @@ test('migration | ember-addon | steps | analyze-addon > test-support', function 
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeAddon(options), {
+  assert.deepStrictEqual(analyzeAddon(options), {
     addon: {
       appReexports: [],
       publicAssets: [],

--- a/tests/migration/ember-addon/steps/analyze-addon/typescript.test.js
+++ b/tests/migration/ember-addon/steps/analyze-addon/typescript.test.js
@@ -11,5 +11,5 @@ import {
 test('migration | ember-addon | steps | analyze-addon > typescript', function () {
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(analyzeAddon(options), context);
+  assert.deepStrictEqual(analyzeAddon(options), context);
 });

--- a/tests/migration/ember-addon/steps/create-options/customizations.test.js
+++ b/tests/migration/ember-addon/steps/create-options/customizations.test.js
@@ -26,7 +26,7 @@ test('migration | ember-addon | steps | create-options > customizations', functi
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     locations: {
       addon: 'packages/ember-container-query',
       testApp: 'demo-app',

--- a/tests/migration/ember-addon/steps/create-options/glint.test.js
+++ b/tests/migration/ember-addon/steps/create-options/glint.test.js
@@ -29,7 +29,7 @@ test('migration | ember-addon | steps | create-options > glint', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     locations: {
       addon: 'ember-container-query',
       testApp: 'test-app',

--- a/tests/migration/ember-addon/steps/create-options/javascript.test.js
+++ b/tests/migration/ember-addon/steps/create-options/javascript.test.js
@@ -26,7 +26,7 @@ test('migration | ember-addon | steps | create-options > javascript', function (
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     locations: {
       addon: 'ember-container-query',
       testApp: 'test-app',

--- a/tests/migration/ember-addon/steps/create-options/npm.test.js
+++ b/tests/migration/ember-addon/steps/create-options/npm.test.js
@@ -32,7 +32,7 @@ test('migration | ember-addon | steps | create-options > npm', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     locations: {
       addon: 'new-v1-addon',
       testApp: 'test-app',

--- a/tests/migration/ember-addon/steps/create-options/pnpm.test.js
+++ b/tests/migration/ember-addon/steps/create-options/pnpm.test.js
@@ -32,7 +32,7 @@ test('migration | ember-addon | steps | create-options > pnpm', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     locations: {
       addon: 'new-v1-addon',
       testApp: 'test-app',

--- a/tests/migration/ember-addon/steps/create-options/scoped.test.js
+++ b/tests/migration/ember-addon/steps/create-options/scoped.test.js
@@ -29,7 +29,7 @@ test('migration | ember-addon | steps | create-options > scoped', function () {
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     locations: {
       addon: 'ember-container-query',
       testApp: 'test-app',

--- a/tests/migration/ember-addon/steps/create-options/typescript.test.js
+++ b/tests/migration/ember-addon/steps/create-options/typescript.test.js
@@ -28,7 +28,7 @@ test('migration | ember-addon | steps | create-options > typescript', function (
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     locations: {
       addon: 'ember-container-query',
       testApp: 'test-app',

--- a/tests/migration/ember-addon/steps/create-options/v2-addon.test.js
+++ b/tests/migration/ember-addon/steps/create-options/v2-addon.test.js
@@ -20,7 +20,7 @@ test('migration | ember-addon | steps | create-options > v2 addon', function () 
 
   loadFixture(inputProject, codemodOptions);
 
-  assert.deepEqual(createOptions(codemodOptions), {
+  assert.deepStrictEqual(createOptions(codemodOptions), {
     locations: {
       addon: 'ember-container-query',
       testApp: 'test-app',


### PR DESCRIPTION
## Description

While [documenting `@codemod-utils/tests`](https://github.com/ijlee2/codemod-utils/pull/11), I learned that `assert.deepEqual` is an alias of `assert.deepStrictEqual` and the latter should be used to avoid unexpected results.

> **Strict assertion mode**
>
> An alias of [assert.deepStrictEqual()](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message).
>
> **Legacy assertion mode**
> 
> [Stability: 3](https://nodejs.org/api/documentation.html#stability-index) - Legacy: Use [assert.deepStrictEqual()](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message) instead.
>
> Tests for deep equality between the actual and expected parameters. Consider using [assert.deepStrictEqual()](https://nodejs.org/api/assert.html#assertdeepstrictequalactual-expected-message) instead. [assert.deepEqual()](https://nodejs.org/api/assert.html#assertdeepequalactual-expected-message) can have surprising results.

https://nodejs.org/api/assert.html#assertdeepequalactual-expected-message