### PR TITLE
Updated @codemod-utils packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,16 +34,16 @@
     "test": "mt tests --quiet"
   },
   "dependencies": {
-    "@codemod-utils/blueprints": "^0.1.2",
-    "@codemod-utils/files": "^0.3.1",
-    "@codemod-utils/json": "^0.2.0",
+    "@codemod-utils/blueprints": "^0.2.0",
+    "@codemod-utils/files": "^0.4.0",
+    "@codemod-utils/json": "^0.3.0",
     "strip-json-comments": "^5.0.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.22.5",
     "@babel/eslint-parser": "^7.22.5",
-    "@codemod-utils/tests": "^0.1.2",
+    "@codemod-utils/tests": "^0.2.1",
     "@sondr3/minitest": "^0.1.1",
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^8.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,14 +2,14 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@codemod-utils/blueprints':
-    specifier: ^0.1.2
-    version: 0.1.2
-  '@codemod-utils/files':
-    specifier: ^0.3.1
-    version: 0.3.1
-  '@codemod-utils/json':
     specifier: ^0.2.0
     version: 0.2.0
+  '@codemod-utils/files':
+    specifier: ^0.4.0
+    version: 0.4.0
+  '@codemod-utils/json':
+    specifier: ^0.3.0
+    version: 0.3.0
   strip-json-comments:
     specifier: ^5.0.0
     version: 5.0.0
@@ -25,8 +25,8 @@ devDependencies:
     specifier: ^7.22.5
     version: 7.22.5(@babel/core@7.22.5)(eslint@8.42.0)
   '@codemod-utils/tests':
-    specifier: ^0.1.2
-    version: 0.1.2(@sondr3/minitest@0.1.1)
+    specifier: ^0.2.1
+    version: 0.2.1(@sondr3/minitest@0.1.1)
   '@sondr3/minitest':
     specifier: ^0.1.1
     version: 0.1.1
@@ -274,27 +274,29 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@codemod-utils/blueprints@0.1.2:
-    resolution: {integrity: sha512-vTCNUooDjPSkQRek5AKeJIkYPPW+cnze7TxaCBqBaoiv0nHYx9wpZSiXq5Z82kf5xHejYoewDUzRkOnlGE8FHw==}
+  /@codemod-utils/blueprints@0.2.0:
+    resolution: {integrity: sha512-u64Ooxb9T8TOvWdrvuXlqRA2rZMA/FPtOwEvrfZvHCGYQ/LUp0vbATD2TauyAvGJ8N+sFd9Jxv5b9/WJZGTWjg==}
     engines: {node: 16.* || >= 18}
     dependencies:
       lodash.template: 4.5.0
     dev: false
 
-  /@codemod-utils/files@0.3.1:
-    resolution: {integrity: sha512-otrfnJBdk4U2RU2C4pjE51c9UTdcgorRpUVlx10iZ1FffYuiES1MYQAZ9jSZDZIjK08GqX4ifZlPVrhGAvoAeg==}
+  /@codemod-utils/files@0.4.0:
+    resolution: {integrity: sha512-chGn+42QqzMP+OrH5fS9SdzUXOPCJhRUkzVd9rzcCCDjhqqK44YvqfhZxE+sAO173BrbmXqjLYqDRdWBUviKGA==}
     engines: {node: 16.* || >= 18}
     dependencies:
       glob: 10.2.7
     dev: false
 
-  /@codemod-utils/json@0.2.0:
-    resolution: {integrity: sha512-ysdsEs6X9TjHHjM36znyj2njmsccil94bMJ90whTn3HH2KCJnMt0SpjFDZk+dJOQP0SFpc9lG5JLA+UwVCit8A==}
+  /@codemod-utils/json@0.3.0:
+    resolution: {integrity: sha512-mwua6fsKxhemCMoSLhJuRVGdD6bIYiryietw4P6nE/GY88TxOy2oBckjY9wJysUGIpqp+dSkLnyEe/CVzvBynQ==}
     engines: {node: 16.* || >= 18}
+    dependencies:
+      type-fest: 3.11.1
     dev: false
 
-  /@codemod-utils/tests@0.1.2(@sondr3/minitest@0.1.1):
-    resolution: {integrity: sha512-h4xs7ybs7N5CvxRWjIAUzLfnOscen7vHe9fCjpRh5X4QuV+L9oQdncqgpLtVlcG6+6K/h+aMQQZy16HXu0KTeA==}
+  /@codemod-utils/tests@0.2.1(@sondr3/minitest@0.1.1):
+    resolution: {integrity: sha512-nW5RrzkWTipx6H+q3P1NOSm919jP8vyIvoONzFAifdapwdKIuphmUKEVDFmRz6ztrlRH/vUYGK1P8OOA47/Saw==}
     engines: {node: 16.* || >= 18}
     peerDependencies:
       '@sondr3/minitest': ^0.1.1
@@ -473,14 +475,14 @@ packages:
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 20.2.6
+      '@types/node': 20.3.0
     dev: true
 
   /@types/glob@8.1.0:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.2.6
+      '@types/node': 20.3.0
     dev: true
 
   /@types/json5@0.0.29:
@@ -495,15 +497,15 @@ packages:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
     dev: true
 
-  /@types/node@20.2.6:
-    resolution: {integrity: sha512-GQBWUtGoefMEOx/vu+emHEHU5aw6JdDoEtZhoBrHFPZbA/YNRFfN996XbBASEWdvmLSLyv9FKYppYGyZjCaq/g==}
+  /@types/node@20.3.0:
+    resolution: {integrity: sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ==}
     dev: true
 
   /@types/rimraf@3.0.2:
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
     dependencies:
       '@types/glob': 8.1.0
-      '@types/node': 20.2.6
+      '@types/node': 20.3.0
     dev: true
 
   /acorn-jsx@5.3.2(acorn@8.8.2):
@@ -2455,6 +2457,11 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
     dev: true
+
+  /type-fest@3.11.1:
+    resolution: {integrity: sha512-aCuRNRERRVh33lgQaJRlUxZqzfhzwTrsE98Mc3o3VXqmiaQdHacgUtJ0esp+7MvZ92qhtzKPeusaX6vIEcoreA==}
+    engines: {node: '>=14.16'}
+    dev: false
 
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}


### PR DESCRIPTION
## Description

Testing [the latest versions of `@codemod-utils`](https://github.com/ijlee2/codemod-utils/releases/tag/0.4.0), which ship types. The pull request checks that a JavaScript project may consume `@codemod-utils` without a problem. Later, we can try to introduce TypeScript to `ember-codemod-v1-to-v2`.