### PR TITLE
Patch #41

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,11 @@
     "test": "tests"
   },
   "files": [
+    "blueprints",
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json && chmod +x dist/bin/ember-codemod-v1-to-v2.js && cp -r blueprints dist/blueprints",
+    "build": "tsc --project tsconfig.build.json && chmod +x dist/bin/ember-codemod-v1-to-v2.js",
     "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
@@ -35,7 +36,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
-    "test": "tsc --build && cp -r blueprints dist/blueprints && mt dist-for-testing --quiet"
+    "test": "tsc --build && mt dist-for-testing --quiet"
   },
   "dependencies": {
     "@codemod-utils/blueprints": "^0.2.0",


### PR DESCRIPTION
## Description

I ran `npx ember-codemod-v1-to-v2@0.7.0` on `ember-container-query` and noticed that `.gitignore`, among other files, got removed.

The installed package's folder structure isn't right either.

<img width="480" alt="" src="https://github.com/ijlee2/ember-codemod-v1-to-v2/assets/16869656/d2b054d4-7c93-4f8e-85e7-b39fa29514c1">
