### PR TITLE
Wrote a shell script to simplify the build and test scripts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,6 +17,7 @@
 /.pnpm-debug.log
 /.prettierignore
 /.prettierrc.cjs
+/build.sh
 /codemod-test-fixture.sh
 /codemod-test-fixtures.sh
 /create-test-fixture.sh

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 ENVIRONMENT=$1
 
-if [ $ENVIRONMENT == "--production" ]
+if [ $ENVIRONMENT = "--production" ]
 then
   # Clean slate
   rm -rf "dist"
@@ -16,7 +16,7 @@ then
 
   echo "SUCCESS: Built dist.\n"
 
-elif [ $ENVIRONMENT == "--test" ]
+elif [ $ENVIRONMENT = "--test" ]
 then
   # Clean slate
   rm -rf "dist-for-testing"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+ENVIRONMENT=$1
+
+if [ $ENVIRONMENT == "--production" ]
+then
+  # Clean slate
+  rm -rf "dist"
+
+  # Compile TypeScript
+  tsc --project "tsconfig.build.json"
+
+  # Configure files
+  chmod +x "dist/bin/ember-codemod-v1-to-v2.js"
+  cp -r "src/blueprints" "dist/src/blueprints"
+
+  echo "SUCCESS: Built dist.\n"
+
+elif [ $ENVIRONMENT == "--test" ]
+then
+  # Clean slate
+  rm -rf "dist-for-testing"
+
+  # Compile TypeScript
+  tsc --project "tsconfig.json"
+
+  # Configure files
+  cp -r "src/blueprints" "dist-for-testing/src/blueprints"
+
+  echo "SUCCESS: Built dist-for-testing.\n"
+
+fi

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --project tsconfig.build.json && chmod +x dist/bin/ember-codemod-v1-to-v2.js && cp -r src/blueprints dist/src/blueprints",
+    "build": "rm -rf dist; tsc --project tsconfig.build.json && chmod +x dist/bin/ember-codemod-v1-to-v2.js && cp -r src/blueprints dist/src/blueprints",
     "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
@@ -35,7 +35,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
-    "test": "tsc --build && cp -r src/blueprints dist-for-testing/src/blueprints && mt dist-for-testing --quiet"
+    "test": "rm -rf dist-for-testing; tsc --build && cp -r src/blueprints dist-for-testing/src/blueprints && mt dist-for-testing --quiet"
   },
   "dependencies": {
     "@codemod-utils/blueprints": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist; tsc --project tsconfig.build.json && chmod +x dist/bin/ember-codemod-v1-to-v2.js && cp -r src/blueprints dist/src/blueprints",
+    "build": "./build.sh --production",
     "changelog": "lerna-changelog",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
@@ -35,7 +35,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --noEmit",
     "prepare": "pnpm build",
-    "test": "rm -rf dist-for-testing; tsc --build && cp -r src/blueprints dist-for-testing/src/blueprints && mt dist-for-testing --quiet"
+    "test": "./build.sh --test && mt dist-for-testing --quiet"
   },
   "dependencies": {
     "@codemod-utils/blueprints": "^0.2.0",


### PR DESCRIPTION
## Description

Tag `0.7.2-alpha.1` contained duplicate files in `src/blueprints`. I likely published the wrong `dist` folder, which had happened a few times before.

<img width="240" alt="" src="https://github.com/ijlee2/ember-codemod-v1-to-v2/assets/16869656/5a314775-6858-428f-af00-deaae08c521f">

To prevent this from happening again, I updated the `build` and `test` script to remove the existing `dist` and `dist-for-testing` folders. To keep the scripts in `package.json` short, I then wrote a shell script (`build.sh`).


## Notes

TLI: I don't have to publish a tag to test the code change.

```sh
npm publish --dry-run
```

<details>

<summary>Output</summary>

```sh
❯ npm publish --dry-run
npm notice 
npm notice 📦  ember-codemod-v1-to-v2@0.7.2-alpha.1
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE.md                                                                                
npm notice 4.8kB README.md                                                                                 
npm notice 1.2kB dist/bin/ember-codemod-v1-to-v2.js                                                        
npm notice 86B   dist/src/blueprints/ember-addon/__addonLocation__/.eslintignore                           
npm notice 115B  dist/src/blueprints/ember-addon/__addonLocation__/addon-main.cjs                          
npm notice 425B  dist/src/blueprints/ember-addon/__addonLocation__/babel.config.json                       
npm notice 2.5kB dist/src/blueprints/ember-addon/__addonLocation__/rollup.config.mjs                       
npm notice 692B  dist/src/blueprints/ember-addon/__addonLocation__/unpublished-development-types/index.d.ts
npm notice 317B  dist/src/blueprints/ember-addon/__gitignore__                                             
npm notice 374B  dist/src/blueprints/ember-addon/__testAppLocation__/ember-cli-build.js                    
npm notice 213B  dist/src/blueprints/ember-addon/__testAppLocation__/types/global.d.ts                     
npm notice 2.8kB dist/src/blueprints/ember-addon/package.json                                              
npm notice 86B   dist/src/blueprints/ember-addon/pnpm-workspace.yaml                                       
npm notice 144B  dist/src/index.js                                                                         
npm notice 952B  dist/src/migration/ember-addon/index.js                                                   
npm notice 1.9kB dist/src/migration/ember-addon/steps/analyze-addon.js                                     
npm notice 1.7kB dist/src/migration/ember-addon/steps/create-files-from-blueprint.js                       
npm notice 2.5kB dist/src/migration/ember-addon/steps/create-options.js                                    
npm notice 450B  dist/src/migration/ember-addon/steps/index.js                                             
npm notice 1.8kB dist/src/migration/ember-addon/steps/move-addon-files.js                                  
npm notice 2.3kB dist/src/migration/ember-addon/steps/move-project-root-files.js                           
npm notice 2.2kB dist/src/migration/ember-addon/steps/move-test-app-files.js                               
npm notice 5.0kB dist/src/migration/ember-addon/steps/update-addon-package-json.js                         
npm notice 1.2kB dist/src/migration/ember-addon/steps/update-addon-tsconfig-json.js                        
npm notice 2.7kB dist/src/migration/ember-addon/steps/update-test-app-package-json.js                      
npm notice 1.3kB dist/src/migration/ember-addon/steps/update-test-app-tsconfig-json.js                     
npm notice 40B   dist/src/migration/index.js                                                               
npm notice 11B   dist/src/types/index.js                                                                   
npm notice 94B   dist/src/utils/blueprints.js                                                              
npm notice 202B  dist/src/utils/blueprints/blueprints-root.js                                              
npm notice 883B  dist/src/utils/blueprints/get-version.js                                                  
npm notice 41B   dist/src/utils/json.js                                                                    
npm notice 172B  dist/src/utils/json/sanitize-json.js                                                      
npm notice 2.5kB package.json                                                                              
npm notice === Tarball Details === 
npm notice name:          ember-codemod-v1-to-v2                  
npm notice version:       0.7.2-alpha.1                           
npm notice filename:      ember-codemod-v1-to-v2-0.7.2-alpha.1.tgz
npm notice package size:  11.2 kB                                 
npm notice unpacked size: 42.6 kB                                 
npm notice shasum:        62458c8cc902da2554debdcabd7b9889d39bb60b
npm notice integrity:     sha512-Z7u9tWZhGa0vO[...]iRHJ8rKR8Wj+A==
npm notice total files:   34                                      
npm notice 
npm notice Publishing to https://registry.npmjs.org/ (dry-run)
+ ember-codemod-v1-to-v2@0.7.2-alpha.1
```

</details>
