### PR TITLE
Replaced @babel/plugin-proposal-class-properties with @babel/plugin-transform-class-properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ If you have an open-sourced addon (v1 or v2) that I can use as a reference, reac
 
 ## Credits
 
-The codemod steps were based on [Migrating an Ember addon to the next-gen v2 format](https://www.kaliber5.de/de/blog/v2-addon_en) and [Guide: Porting an Addon to v2](https://github.com/embroider-build/embroider/blob/v3.1.1-core/docs/porting-addons-to-v2.md). The blueprints were derived from [`@embroider/addon-blueprint`](https://github.com/embroider-build/addon-blueprint).
+The codemod steps were based on [Migrating an Ember addon to the next-gen v2 format](https://www.kaliber5.de/de/blog/v2-addon_en) and [Guide: Porting an Addon to v2](https://github.com/embroider-build/embroider/blob/v3.1.3-core/docs/porting-addons-to-v2.md). The blueprints were derived from [`@embroider/addon-blueprint`](https://github.com/embroider-build/addon-blueprint).
 
 
 ## License

--- a/src/blueprints/ember-addon/__addonLocation__/babel.config.json
+++ b/src/blueprints/ember-addon/__addonLocation__/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",<% if (options.packages.addon.hasTypeScript) { %>
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],<% } %>
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/src/migration/ember-addon/steps/update-addon-package-json/update-dev-dependencies.ts
+++ b/src/migration/ember-addon/steps/update-addon-package-json/update-dev-dependencies.ts
@@ -25,8 +25,8 @@ export function updateDevDependencies(
 
   const packagesToInstall = new Set([
     '@babel/core',
-    '@babel/plugin-proposal-class-properties',
     '@babel/plugin-proposal-decorators',
+    '@babel/plugin-transform-class-properties',
     '@babel/runtime',
     '@embroider/addon-dev',
     '@rollup/plugin-babel',

--- a/src/utils/blueprints/get-version.ts
+++ b/src/utils/blueprints/get-version.ts
@@ -4,8 +4,8 @@ import type { Options } from '../../types/index.js';
 
 const latestVersions = new Map([
   ['@babel/core', '7.22.6'],
-  ['@babel/plugin-proposal-class-properties', '7.18.6'],
   ['@babel/plugin-proposal-decorators', '7.22.6'],
+  ['@babel/plugin-transform-class-properties', '7.22.5'],
   ['@babel/preset-typescript', '7.22.5'],
   ['@babel/runtime', '7.22.6'],
   ['@embroider/addon-dev', '3.1.1'],

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
@@ -68,8 +68,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
@@ -68,8 +68,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/babel.config.json
@@ -2,6 +2,6 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
@@ -61,8 +61,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",
     "@rollup/plugin-babel": "^6.0.3",

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
@@ -68,8 +68,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
@@ -68,8 +68,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
@@ -38,8 +38,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/babel.config.json
@@ -2,6 +2,6 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
@@ -31,8 +31,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",
     "@rollup/plugin-babel": "^6.0.3",

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/babel.config.json
@@ -2,6 +2,6 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
@@ -31,8 +31,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",
     "@rollup/plugin-babel": "^6.0.3",

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/babel.config.json
@@ -2,6 +2,6 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
@@ -31,8 +31,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",
     "@rollup/plugin-babel": "^6.0.3",

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
@@ -38,8 +38,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",

--- a/tests/fixtures/steps/create-files-from-blueprints/customizations/output/packages/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/customizations/output/packages/ember-container-query/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/glint/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/glint/output/ember-container-query/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-container-query/babel.config.json
@@ -2,6 +2,6 @@
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/npm/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/npm/output/ember-container-query/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/pnpm/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/pnpm/output/ember-container-query/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/scoped/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/scoped/output/ember-container-query/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-container-query/babel.config.json
@@ -4,6 +4,6 @@
     "@embroider/addon-dev/template-colocation-plugin",
     ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-class-properties"
   ]
 }

--- a/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
@@ -68,8 +68,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",

--- a/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
@@ -68,8 +68,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",

--- a/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
@@ -61,8 +61,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.20.7",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",
     "@rollup/plugin-babel": "^6.0.3",

--- a/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
@@ -68,8 +68,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",

--- a/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
@@ -68,8 +68,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",

--- a/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
@@ -68,8 +68,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.6",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.22.6",
+    "@babel/plugin-transform-class-properties": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@babel/runtime": "^7.22.6",
     "@embroider/addon-dev": "^3.1.1",


### PR DESCRIPTION
## Description

Downstreams changes from https://github.com/embroider-build/embroider/pull/1520.

The Babel plugin had been renamed to `@babel/plugin-transform-class-properties` (there have been no recent releases for the plugin with the old name).