### PR TITLE
Configured allowImportingTsExtensions in the addon's tsconfig.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ npx ember-codemod-v1-to-v2 <arguments>
 Step 2. Review the addon package.
 
 - [x] Update the configuration files.<sup>2</sup>
+- [x] Relative import paths must specify the file extension `.js` or `.ts`.
 - [x] Colocate stylesheets (if any). Let each component import the relevant stylesheet in the backing class.
 - [x] Confirm that you can run all scripts in `package.json`.
 

--- a/src/steps/update-addon-tsconfig-json.ts
+++ b/src/steps/update-addon-tsconfig-json.ts
@@ -18,8 +18,10 @@ function updateCompilerOptions(
   compilerOptions.delete('paths');
 
   if (packages.addon.hasGlint) {
+    compilerOptions.set('allowImportingTsExtensions', true);
     compilerOptions.set('declarationDir', 'declarations');
   } else {
+    compilerOptions.set('allowImportingTsExtensions', true);
     compilerOptions.set('declaration', true);
     compilerOptions.set('declarationDir', 'declarations');
     compilerOptions.set('emitDeclarationOnly', true);

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declarationDir": "declarations",
     "skipLibCheck": true
   },

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declarationDir": "declarations",
     "skipLibCheck": true
   },

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declarationDir": "declarations",
     "skipLibCheck": true
   },

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declaration": true,
     "declarationDir": "declarations",
     "emitDeclarationOnly": true,

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/tsconfig.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declaration": true,
     "declarationDir": "declarations",
     "emitDeclarationOnly": true,

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/tsconfig.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declaration": true,
     "declarationDir": "declarations",
     "emitDeclarationOnly": true,

--- a/tests/fixtures/steps/update-addon-tsconfig-json/customizations/output/packages/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/customizations/output/packages/ember-container-query/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declarationDir": "declarations",
     "skipLibCheck": true
   },

--- a/tests/fixtures/steps/update-addon-tsconfig-json/glint/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/glint/output/ember-container-query/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declarationDir": "declarations",
     "skipLibCheck": true
   },

--- a/tests/fixtures/steps/update-addon-tsconfig-json/scoped/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/scoped/output/ember-container-query/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declarationDir": "declarations",
     "skipLibCheck": true
   },

--- a/tests/fixtures/steps/update-addon-tsconfig-json/typescript/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/typescript/output/ember-container-query/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/ember/tsconfig.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "declaration": true,
     "declarationDir": "declarations",
     "emitDeclarationOnly": true,


### PR DESCRIPTION
## Description

Downstreamed a bug fix in [@embroider/addon-blueprint#160](https://github.com/embroider-build/addon-blueprint/pull/160).

As indicated in the [release notes for tag `0.9.1`](https://github.com/ijlee2/ember-codemod-v1-to-v2/releases/tag/0.9.1), a TypeScript addon (created with `@embroider/addon-blueprint`) must now:

- Set `allowImportingTsExtensions` to `true` in `tsconfig.json`
- Add the file extension `.ts` to all relative import paths

In this pull request, I allowed the codemod to configure `allowImportingTsExtensions` for the end-developer. Adding the file extension `.ts` is out of scope (i.e. for now, the end-developer must manually add it), but may be considered at a later point.
