### PR TITLE
Updated blueprints

### DIFF
--- a/src/utils/blueprints/get-version.ts
+++ b/src/utils/blueprints/get-version.ts
@@ -3,19 +3,19 @@ import { decideVersion } from '@codemod-utils/blueprints';
 import type { Options } from '../../types/index.js';
 
 const latestVersions = new Map([
-  ['@babel/core', '7.22.10'],
+  ['@babel/core', '7.22.11'],
   ['@babel/plugin-proposal-decorators', '7.22.10'],
   ['@babel/plugin-transform-class-properties', '7.22.5'],
-  ['@babel/preset-typescript', '7.22.5'],
-  ['@babel/runtime', '7.22.10'],
+  ['@babel/preset-typescript', '7.22.11'],
+  ['@babel/runtime', '7.22.11'],
   ['@embroider/addon-dev', '4.1.0'],
   ['@embroider/addon-shim', '1.8.6'],
   ['@rollup/plugin-babel', '6.0.3'],
-  ['concurrently', '8.2.0'],
+  ['concurrently', '8.2.1'],
   ['ember-auto-import', '2.6.3'],
-  ['ember-cli-babel', '7.26.11'],
+  ['ember-cli-babel', '8.0.0'],
   ['ember-cli-htmlbars', '6.3.0'],
-  ['rollup', '3.28.0'],
+  ['rollup', '3.28.1'],
   ['rollup-plugin-copy', '3.4.0'],
 ]);
 

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
@@ -67,15 +67,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
@@ -67,15 +67,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
@@ -60,14 +60,14 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.20.7",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
@@ -67,15 +67,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
@@ -67,15 +67,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
@@ -37,15 +37,15 @@
     "ember-cli-typescript": "^5.2.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
@@ -30,14 +30,14 @@
     "@embroider/addon-shim": "^1.8.6"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
@@ -30,14 +30,14 @@
     "@embroider/addon-shim": "^1.8.6"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
@@ -30,14 +30,14 @@
     "@embroider/addon-shim": "^1.8.6"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
@@ -37,15 +37,15 @@
     "ember-cli-typescript": "^5.2.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
@@ -67,15 +67,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
@@ -67,15 +67,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
@@ -60,14 +60,14 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.20.7",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
@@ -67,15 +67,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
@@ -67,15 +67,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
@@ -67,15 +67,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.10",
+    "@babel/core": "^7.22.11",
     "@babel/plugin-proposal-decorators": "^7.22.10",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.5",
-    "@babel/runtime": "^7.22.10",
+    "@babel/preset-typescript": "^7.22.11",
+    "@babel/runtime": "^7.22.11",
     "@embroider/addon-dev": "^4.1.0",
     "@rollup/plugin-babel": "^6.0.3",
     "concurrently": "^7.6.0",
-    "rollup": "^3.28.0",
+    "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0"
   },
   "engines": {


### PR DESCRIPTION
## Description

Similarly to in #63, I updated the versions of the dependencies that `ember-codemod-v1-to-v2` would install when a package is missing.