### PR TITLE
Downstreamed changes from @embroider/addon-blueprint@2.7.0

### DIFF
--- a/src/blueprints/ember-addon/__addonLocation__/babel.config.json
+++ b/src/blueprints/ember-addon/__addonLocation__/babel.config.json
@@ -1,15 +1,23 @@
-<% if (options.packages.addon.hasTypeScript) { %>{
-  "presets": [["@babel/preset-typescript"]],
+{
   "plugins": [
-    "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+<% if (options.packages.addon.hasTypeScript) { %>    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
+<% } %>    "@embroider/addon-dev/template-colocation-plugin",
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]
-}<% } else { %>{
-  "plugins": [
-    "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
-  ]
-}<% } %>
+}

--- a/src/blueprints/ember-addon/__addonLocation__/rollup.config.mjs
+++ b/src/blueprints/ember-addon/__addonLocation__/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints([<%= context.addon.publicEntrypoints.map((filePath) => `'${filePath}'`).join(', ') %>]),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js'<% if (options.packages.addon.hasGlint) {%>, 'template-registry.js'<% } %>]),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports([<%= context.addon.appReexports.map((filePath) => `'${filePath}'`).join(', ') %>]),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js'<% if (options.packages.addon.hasTypeScript) { %>, '.ts'<% } %>],
+      extensions: ['.js', '.gjs'<% if (options.packages.addon.hasTypeScript) { %>, '.ts', '.gts'<% } %>],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/src/steps/analyze-addon.ts
+++ b/src/steps/analyze-addon.ts
@@ -3,23 +3,6 @@ import { findFiles, renamePathByDirectory } from '@codemod-utils/files';
 import type { Context, Options } from '../types/index.js';
 import { getVersion } from '../utils/blueprints.js';
 
-function getAppReexports(options: Options): string[] {
-  const { projectRoot } = options;
-
-  const filePaths = findFiles('app/**/*.js', {
-    projectRoot,
-  });
-
-  return filePaths
-    .map((filePath) => {
-      return renamePathByDirectory(filePath, {
-        from: 'app',
-        to: '',
-      });
-    })
-    .sort();
-}
-
 function getProjectRootDevDependencies(
   options: Options,
 ): Record<string, string> {
@@ -45,38 +28,10 @@ function getPublicAssets(options: Options): string[] {
     .sort();
 }
 
-function getPublicEntrypoints(options: Options): string[] {
-  const { projectRoot } = options;
-
-  const filePaths = findFiles('{addon,addon-test-support}/**/*.{js,ts}', {
-    projectRoot,
-  });
-
-  return filePaths
-    .map((filePath) => {
-      return renamePathByDirectory(filePath, {
-        from: 'addon',
-        to: '',
-      });
-    })
-    .map((filePath) => {
-      return renamePathByDirectory(filePath, {
-        from: 'addon-test-support',
-        to: 'test-support',
-      });
-    })
-    .map((filePath) => {
-      return filePath.replace(/(?<!\.d)\.ts$/, '.js');
-    })
-    .sort();
-}
-
 export function analyzeAddon(options: Options): Context {
   return {
     addon: {
-      appReexports: getAppReexports(options),
       publicAssets: getPublicAssets(options),
-      publicEntrypoints: getPublicEntrypoints(options),
     },
     projectRoot: {
       devDependencies: getProjectRootDevDependencies(options),

--- a/src/steps/update-addon-package-json/update-dependencies.ts
+++ b/src/steps/update-addon-package-json/update-dependencies.ts
@@ -9,14 +9,18 @@ export function updateDependencies(
 ): void {
   const dependencies = convertToMap(packageJson['dependencies']);
 
-  const packagesToDelete = [
+  const packagesToDelete = new Set([
     '@embroider/macros',
     'ember-auto-import',
     'ember-cli-babel',
     'ember-cli-htmlbars',
-  ];
+  ]);
 
-  packagesToDelete.forEach((packageName) => {
+  if (options.packages.addon.hasTypeScript) {
+    packagesToDelete.add('ember-cli-typescript');
+  }
+
+  Array.from(packagesToDelete).forEach((packageName) => {
     dependencies.delete(packageName);
   });
 

--- a/src/steps/update-addon-package-json/update-dev-dependencies.ts
+++ b/src/steps/update-addon-package-json/update-dev-dependencies.ts
@@ -39,6 +39,7 @@ export function updateDevDependencies(
 
   if (packages.addon.hasTypeScript) {
     packagesToInstall.add('@babel/plugin-transform-typescript');
+    packagesToInstall.add('@tsconfig/ember');
     packagesToInstall.add('typescript');
   }
 

--- a/src/steps/update-addon-package-json/update-dev-dependencies.ts
+++ b/src/steps/update-addon-package-json/update-dev-dependencies.ts
@@ -27,16 +27,18 @@ export function updateDevDependencies(
     '@babel/core',
     '@babel/plugin-proposal-decorators',
     '@babel/plugin-transform-class-properties',
+    '@babel/plugin-transform-class-static-block',
     '@babel/runtime',
     '@embroider/addon-dev',
     '@rollup/plugin-babel',
+    'babel-plugin-ember-template-compilation',
     'concurrently',
     'rollup',
     'rollup-plugin-copy',
   ]);
 
   if (packages.addon.hasTypeScript) {
-    packagesToInstall.add('@babel/preset-typescript');
+    packagesToInstall.add('@babel/plugin-transform-typescript');
   }
 
   Array.from(packagesToInstall).forEach((packageName) => {

--- a/src/steps/update-addon-package-json/update-dev-dependencies.ts
+++ b/src/steps/update-addon-package-json/update-dev-dependencies.ts
@@ -39,6 +39,7 @@ export function updateDevDependencies(
 
   if (packages.addon.hasTypeScript) {
     packagesToInstall.add('@babel/plugin-transform-typescript');
+    packagesToInstall.add('typescript');
   }
 
   Array.from(packagesToInstall).forEach((packageName) => {

--- a/src/steps/update-addon-package-json/update-scripts.ts
+++ b/src/steps/update-addon-package-json/update-scripts.ts
@@ -25,6 +25,10 @@ export function updateScripts(
         : 'tsc --emitDeclarationOnly false --noEmit',
     );
 
+    if (scripts.get('postpack') === 'ember ts:clean') {
+      scripts.delete('postpack');
+    }
+
     scripts.set('prepack', 'rollup --config');
 
     scripts.set('start', 'concurrently "npm:start:*" --names "start:"');

--- a/src/steps/update-addon-tsconfig-json.ts
+++ b/src/steps/update-addon-tsconfig-json.ts
@@ -6,26 +6,24 @@ import { convertToMap, convertToObject } from '@codemod-utils/json';
 import type { Options, TsConfigJson } from '../types/index.js';
 import { sanitizeJson } from '../utils/json.js';
 
-function updateCompilerOptions(
+function setExtends(tsConfigJson: TsConfigJson): void {
+  tsConfigJson['extends'] = '@tsconfig/ember/tsconfig.json';
+}
+
+function setCompilerOptions(
   tsConfigJson: TsConfigJson,
   options: Options,
 ): void {
   const { packages } = options;
 
-  const compilerOptions = convertToMap(tsConfigJson['compilerOptions']);
+  const compilerOptions = convertToMap();
 
-  compilerOptions.delete('baseUrl');
-  compilerOptions.delete('paths');
+  compilerOptions.set('allowImportingTsExtensions', true);
+  compilerOptions.set('allowJs', true);
+  compilerOptions.set('declarationDir', 'declarations');
 
-  if (packages.addon.hasGlint) {
-    compilerOptions.set('allowImportingTsExtensions', true);
-    compilerOptions.set('allowJs', true);
-    compilerOptions.set('declarationDir', 'declarations');
-  } else {
-    compilerOptions.set('allowImportingTsExtensions', true);
-    compilerOptions.set('allowJs', true);
+  if (!packages.addon.hasGlint) {
     compilerOptions.set('declaration', true);
-    compilerOptions.set('declarationDir', 'declarations');
     compilerOptions.set('emitDeclarationOnly', true);
     compilerOptions.set('noEmit', false);
   }
@@ -33,7 +31,7 @@ function updateCompilerOptions(
   tsConfigJson['compilerOptions'] = convertToObject(compilerOptions);
 }
 
-function updateInclude(tsConfigJson: TsConfigJson): void {
+function setInclude(tsConfigJson: TsConfigJson): void {
   tsConfigJson['include'] = ['src/**/*', 'unpublished-development-types/**/*'];
 }
 
@@ -48,8 +46,9 @@ export function updateAddonTsConfigJson(options: Options): void {
   const oldFile = readFileSync(oldPath, 'utf8');
   const tsConfigJson = JSON.parse(sanitizeJson(oldFile));
 
-  updateCompilerOptions(tsConfigJson, options);
-  updateInclude(tsConfigJson);
+  setExtends(tsConfigJson);
+  setCompilerOptions(tsConfigJson, options);
+  setInclude(tsConfigJson);
 
   const newFile = JSON.stringify(tsConfigJson, null, 2) + '\n';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,9 +9,7 @@ type CodemodOptions = {
 
 type Context = {
   addon: {
-    appReexports: string[];
     publicAssets: string[];
-    publicEntrypoints: string[];
   };
   projectRoot: {
     devDependencies: Record<string, string>;

--- a/src/utils/blueprints/get-version.ts
+++ b/src/utils/blueprints/get-version.ts
@@ -3,20 +3,22 @@ import { decideVersion } from '@codemod-utils/blueprints';
 import type { Options } from '../../types/index.js';
 
 const latestVersions = new Map([
-  ['@babel/core', '7.22.17'],
+  ['@babel/core', '7.23.2'],
   ['@babel/plugin-proposal-decorators', '7.22.15'],
   ['@babel/plugin-transform-class-properties', '7.22.5'],
-  ['@babel/preset-typescript', '7.22.15'],
-  ['@babel/runtime', '7.22.15'],
-  ['@embroider/addon-dev', '4.1.0'],
+  ['@babel/plugin-transform-class-static-block', '7.22.11'],
+  ['@babel/plugin-transform-typescript', '7.22.15'],
+  ['@babel/runtime', '7.23.2'],
+  ['@embroider/addon-dev', '4.1.1'],
   ['@embroider/addon-shim', '1.8.6'],
-  ['@embroider/test-setup', '3.0.1'],
-  ['@rollup/plugin-babel', '6.0.3'],
-  ['concurrently', '8.2.1'],
+  ['@embroider/test-setup', '3.0.2'],
+  ['@rollup/plugin-babel', '6.0.4'],
+  ['babel-plugin-ember-template-compilation', '2.2.1'],
+  ['concurrently', '8.2.2'],
   ['ember-auto-import', '2.6.3'],
-  ['ember-cli-babel', '8.0.0'],
+  ['ember-cli-babel', '8.1.0'],
   ['ember-cli-htmlbars', '6.3.0'],
-  ['rollup', '3.29.1'],
+  ['rollup', '4.3.0'],
   ['rollup-plugin-copy', '3.5.0'],
 ]);
 

--- a/src/utils/blueprints/get-version.ts
+++ b/src/utils/blueprints/get-version.ts
@@ -13,6 +13,7 @@ const latestVersions = new Map([
   ['@embroider/addon-shim', '1.8.6'],
   ['@embroider/test-setup', '3.0.2'],
   ['@rollup/plugin-babel', '6.0.4'],
+  ['@tsconfig/ember', '3.0.2'],
   ['babel-plugin-ember-template-compilation', '2.2.1'],
   ['concurrently', '8.2.2'],
   ['ember-auto-import', '2.6.3'],

--- a/src/utils/blueprints/get-version.ts
+++ b/src/utils/blueprints/get-version.ts
@@ -20,6 +20,7 @@ const latestVersions = new Map([
   ['ember-cli-htmlbars', '6.3.0'],
   ['rollup', '4.3.0'],
   ['rollup-plugin-copy', '3.5.0'],
+  ['typescript', '5.2.2'],
 ]);
 
 export function getVersion(packageName: string, options: Options): string {

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
@@ -39,7 +39,6 @@
     "lint:js": "eslint . --cache --ext=.js,.ts",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "glint",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -60,7 +59,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -78,7 +76,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
@@ -67,15 +67,17 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
@@ -73,6 +73,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js', 'template-registry.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations",
-    "skipLibCheck": true
+    "declarationDir": "declarations"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
@@ -39,7 +39,6 @@
     "lint:js": "eslint . --cache --ext=.js,.ts",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "glint",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -60,7 +59,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -78,7 +76,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
@@ -67,15 +67,17 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
@@ -73,6 +73,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js', 'template-registry.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations",
-    "skipLibCheck": true
+    "declarationDir": "declarations"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/babel.config.json
@@ -1,6 +1,14 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
@@ -60,14 +60,16 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.20.7",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js'],
+      extensions: ['.js', '.gjs'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
@@ -39,7 +39,6 @@
     "lint:js": "eslint . --cache --ext=.js,.ts",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "glint",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -60,7 +59,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -78,7 +76,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
@@ -67,15 +67,17 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
@@ -73,6 +73,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js', 'template-registry.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations",
-    "skipLibCheck": true
+    "declarationDir": "declarations"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
@@ -67,15 +67,17 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
@@ -73,6 +73,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
@@ -39,7 +39,6 @@
     "lint:js": "eslint . --cache --ext=.js,.ts",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --emitDeclarationOnly false --noEmit",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -60,7 +59,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -78,7 +76,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/tsconfig.json
@@ -6,8 +6,7 @@
     "declaration": true,
     "declarationDir": "declarations",
     "emitDeclarationOnly": true,
-    "noEmit": false,
-    "skipLibCheck": true
+    "noEmit": false
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
@@ -37,15 +37,17 @@
     "ember-cli-typescript": "^5.2.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
@@ -23,7 +23,6 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --emitDeclarationOnly false --noEmit",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -33,8 +32,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1"
+    "@embroider/addon-shim": "^1.8.6"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
@@ -48,7 +46,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "peerDependencies": {
     "ember-source": "^3.28.0 || ^4.0.0"

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
@@ -43,6 +43,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/rollup.config.mjs
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints([]),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports([]),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/babel.config.json
@@ -1,6 +1,14 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
@@ -30,14 +30,16 @@
     "@embroider/addon-shim": "^1.8.6"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/rollup.config.mjs
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints([]),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports([]),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js'],
+      extensions: ['.js', '.gjs'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/babel.config.json
@@ -1,6 +1,14 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
@@ -30,14 +30,16 @@
     "@embroider/addon-shim": "^1.8.6"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/rollup.config.mjs
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints([]),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports([]),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js'],
+      extensions: ['.js', '.gjs'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/babel.config.json
@@ -1,6 +1,14 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
@@ -30,14 +30,16 @@
     "@embroider/addon-shim": "^1.8.6"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/rollup.config.mjs
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints([]),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports([]),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js'],
+      extensions: ['.js', '.gjs'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
@@ -37,15 +37,17 @@
     "ember-cli-typescript": "^5.2.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
@@ -23,7 +23,6 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --emitDeclarationOnly false --noEmit",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -33,8 +32,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1"
+    "@embroider/addon-shim": "^1.8.6"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
@@ -48,7 +46,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "peerDependencies": {
     "ember-source": "^3.28.0 || ^4.0.0"

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
@@ -43,6 +43,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/rollup.config.mjs
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints([]),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports([]),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/steps/create-files-from-blueprints/customizations/output/packages/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/customizations/output/packages/ember-container-query/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/steps/create-files-from-blueprints/customizations/output/packages/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprints/customizations/output/packages/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js', 'template-registry.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/steps/create-files-from-blueprints/glint/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/glint/output/ember-container-query/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/steps/create-files-from-blueprints/glint/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprints/glint/output/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js', 'template-registry.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-container-query/babel.config.json
@@ -1,6 +1,14 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js'],
+      extensions: ['.js', '.gjs'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/steps/create-files-from-blueprints/npm/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/npm/output/ember-container-query/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/steps/create-files-from-blueprints/npm/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprints/npm/output/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/steps/create-files-from-blueprints/pnpm/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/pnpm/output/ember-container-query/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/steps/create-files-from-blueprints/pnpm/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprints/pnpm/output/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/steps/create-files-from-blueprints/scoped/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/scoped/output/ember-container-query/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/steps/create-files-from-blueprints/scoped/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprints/scoped/output/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js', 'template-registry.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js', 'template-registry.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-container-query/babel.config.json
@@ -1,8 +1,22 @@
 {
-  "presets": [["@babel/preset-typescript"]],
   "plugins": [
+    [
+      "@babel/plugin-transform-typescript",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "onlyRemoveTypeImports": true
+      }
+    ],
     "@embroider/addon-dev/template-colocation-plugin",
-    ["@babel/plugin-transform-typescript", { "allowDeclareFields": true }],
+    "@babel/plugin-transform-class-static-block",
+    [
+      "babel-plugin-ember-template-compilation",
+      {
+        "targetFormat": "hbs",
+        "transforms": []
+      }
+    ],
     ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
     "@babel/plugin-transform-class-properties"
   ]

--- a/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-container-query/rollup.config.mjs
+++ b/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-container-query/rollup.config.mjs
@@ -15,12 +15,22 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'index.js', 'modifiers/container-query.js']),
+    // By default all your JavaScript modules (**/*.js) will be importable.
+    // But you are encouraged to tweak this to only cover the modules that make
+    // up your addon's public API. Also make sure your package.json#exports
+    // is aligned to the config here.
+    // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
+    addon.publicEntrypoints(['**/*.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but
     // not everything in publicEntrypoints necessarily needs to go here.
-    addon.appReexports(['components/container-query.js', 'helpers/aspect-ratio.js', 'helpers/cq-aspect-ratio.js', 'helpers/cq-height.js', 'helpers/cq-width.js', 'helpers/height.js', 'helpers/width.js', 'modifiers/container-query.js']),
+    addon.appReexports([
+      'components/**/*.js',
+      'helpers/**/*.js',
+      'modifiers/**/*.js',
+      'services/**/*.js',
+    ]),
 
     // Follow the V2 Addon rules about dependencies. Your code can import from
     // `dependencies` and `peerDependencies` as well as standard Ember-provided
@@ -35,11 +45,14 @@ export default {
     // babel.config.json.
     babel({
       babelHelpers: 'bundled',
-      extensions: ['.js', '.ts'],
+      extensions: ['.js', '.gjs', '.ts', '.gts'],
     }),
 
     // Ensure that standalone .hbs files are properly integrated as Javascript.
     addon.hbs(),
+
+    // Ensure that .gjs files are properly integrated as Javascript
+    addon.gjs(),
 
     // addons are allowed to contain imports of .css files, which we want rollup
     // to leave alone and keep in the published output.

--- a/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
@@ -39,7 +39,6 @@
     "lint:js": "eslint . --cache --ext=.js,.ts",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "glint",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -60,7 +59,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -78,7 +76,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
@@ -67,15 +67,17 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
@@ -73,6 +73,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
@@ -39,7 +39,6 @@
     "lint:js": "eslint . --cache --ext=.js,.ts",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "glint",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -60,7 +59,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -78,7 +76,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
@@ -67,15 +67,17 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
@@ -73,6 +73,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
@@ -60,14 +60,16 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.20.7",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
@@ -67,15 +67,17 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
@@ -73,6 +73,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
@@ -39,7 +39,6 @@
     "lint:js": "eslint . --cache --ext=.js,.ts",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --emitDeclarationOnly false --noEmit",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -60,7 +59,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -78,7 +76,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
@@ -39,7 +39,6 @@
     "lint:js": "eslint . --cache --ext=.js,.ts",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "glint",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -60,7 +59,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -78,7 +76,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
@@ -67,15 +67,17 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
@@ -73,6 +73,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
@@ -67,15 +67,17 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.17",
+    "@babel/core": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.22.15",
     "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/preset-typescript": "^7.22.15",
-    "@babel/runtime": "^7.22.15",
-    "@embroider/addon-dev": "^4.1.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@babel/plugin-transform-class-static-block": "^7.22.11",
+    "@babel/plugin-transform-typescript": "^7.22.15",
+    "@babel/runtime": "^7.23.2",
+    "@embroider/addon-dev": "^4.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^3.29.1",
+    "rollup": "^4.3.0",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
@@ -73,6 +73,7 @@
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",
+    "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",

--- a/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
@@ -39,7 +39,6 @@
     "lint:js": "eslint . --cache --ext=.js,.ts",
     "lint:js:fix": "eslint . --fix",
     "lint:types": "tsc --emitDeclarationOnly false --noEmit",
-    "postpack": "ember ts:clean",
     "prepack": "rollup --config",
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
@@ -60,7 +59,6 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
-    "ember-cli-typescript": "^5.2.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -78,7 +76,8 @@
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
     "rollup": "^4.3.0",
-    "rollup-plugin-copy": "^3.5.0"
+    "rollup-plugin-copy": "^3.5.0",
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"

--- a/tests/fixtures/steps/update-addon-tsconfig-json/customizations/output/packages/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/customizations/output/packages/ember-container-query/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations",
-    "skipLibCheck": true
+    "declarationDir": "declarations"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/steps/update-addon-tsconfig-json/glint/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/glint/output/ember-container-query/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations",
-    "skipLibCheck": true
+    "declarationDir": "declarations"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/steps/update-addon-tsconfig-json/scoped/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/scoped/output/ember-container-query/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations",
-    "skipLibCheck": true
+    "declarationDir": "declarations"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/steps/update-addon-tsconfig-json/typescript/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/typescript/output/ember-container-query/tsconfig.json
@@ -6,8 +6,7 @@
     "declaration": true,
     "declarationDir": "declarations",
     "emitDeclarationOnly": true,
-    "noEmit": false,
-    "skipLibCheck": true
+    "noEmit": false
   },
   "include": [
     "src/**/*",

--- a/tests/helpers/shared-test-setups/customizations.ts
+++ b/tests/helpers/shared-test-setups/customizations.ts
@@ -13,29 +13,7 @@ const codemodOptions: CodemodOptions = {
 
 const context: Context = {
   addon: {
-    appReexports: [
-      'components/container-query.js',
-      'helpers/aspect-ratio.js',
-      'helpers/cq-aspect-ratio.js',
-      'helpers/cq-height.js',
-      'helpers/cq-width.js',
-      'helpers/height.js',
-      'helpers/width.js',
-      'modifiers/container-query.js',
-    ],
     publicAssets: [],
-    publicEntrypoints: [
-      'components/container-query.js',
-      'helpers/aspect-ratio.js',
-      'helpers/cq-aspect-ratio.js',
-      'helpers/cq-height.js',
-      'helpers/cq-width.js',
-      'helpers/height.js',
-      'helpers/width.js',
-      'index.js',
-      'modifiers/container-query.js',
-      'template-registry.js',
-    ],
   },
   projectRoot: {
     devDependencies: {

--- a/tests/helpers/shared-test-setups/glint.ts
+++ b/tests/helpers/shared-test-setups/glint.ts
@@ -13,29 +13,7 @@ const codemodOptions: CodemodOptions = {
 
 const context: Context = {
   addon: {
-    appReexports: [
-      'components/container-query.js',
-      'helpers/aspect-ratio.js',
-      'helpers/cq-aspect-ratio.js',
-      'helpers/cq-height.js',
-      'helpers/cq-width.js',
-      'helpers/height.js',
-      'helpers/width.js',
-      'modifiers/container-query.js',
-    ],
     publicAssets: [],
-    publicEntrypoints: [
-      'components/container-query.js',
-      'helpers/aspect-ratio.js',
-      'helpers/cq-aspect-ratio.js',
-      'helpers/cq-height.js',
-      'helpers/cq-width.js',
-      'helpers/height.js',
-      'helpers/width.js',
-      'index.js',
-      'modifiers/container-query.js',
-      'template-registry.js',
-    ],
   },
   projectRoot: {
     devDependencies: {

--- a/tests/helpers/shared-test-setups/javascript.ts
+++ b/tests/helpers/shared-test-setups/javascript.ts
@@ -13,27 +13,7 @@ const codemodOptions: CodemodOptions = {
 
 const context: Context = {
   addon: {
-    appReexports: [
-      'components/container-query.js',
-      'helpers/aspect-ratio.js',
-      'helpers/cq-aspect-ratio.js',
-      'helpers/cq-height.js',
-      'helpers/cq-width.js',
-      'helpers/height.js',
-      'helpers/width.js',
-      'modifiers/container-query.js',
-    ],
     publicAssets: [],
-    publicEntrypoints: [
-      'components/container-query.js',
-      'helpers/aspect-ratio.js',
-      'helpers/cq-aspect-ratio.js',
-      'helpers/cq-height.js',
-      'helpers/cq-width.js',
-      'helpers/height.js',
-      'helpers/width.js',
-      'modifiers/container-query.js',
-    ],
   },
   projectRoot: {
     devDependencies: {

--- a/tests/helpers/shared-test-setups/scoped.ts
+++ b/tests/helpers/shared-test-setups/scoped.ts
@@ -13,29 +13,7 @@ const codemodOptions: CodemodOptions = {
 
 const context: Context = {
   addon: {
-    appReexports: [
-      'components/container-query.js',
-      'helpers/aspect-ratio.js',
-      'helpers/cq-aspect-ratio.js',
-      'helpers/cq-height.js',
-      'helpers/cq-width.js',
-      'helpers/height.js',
-      'helpers/width.js',
-      'modifiers/container-query.js',
-    ],
     publicAssets: [],
-    publicEntrypoints: [
-      'components/container-query.js',
-      'helpers/aspect-ratio.js',
-      'helpers/cq-aspect-ratio.js',
-      'helpers/cq-height.js',
-      'helpers/cq-width.js',
-      'helpers/height.js',
-      'helpers/width.js',
-      'index.js',
-      'modifiers/container-query.js',
-      'template-registry.js',
-    ],
   },
   projectRoot: {
     devDependencies: {

--- a/tests/helpers/shared-test-setups/typescript.ts
+++ b/tests/helpers/shared-test-setups/typescript.ts
@@ -13,28 +13,7 @@ const codemodOptions: CodemodOptions = {
 
 const context: Context = {
   addon: {
-    appReexports: [
-      'components/container-query.js',
-      'helpers/aspect-ratio.js',
-      'helpers/cq-aspect-ratio.js',
-      'helpers/cq-height.js',
-      'helpers/cq-width.js',
-      'helpers/height.js',
-      'helpers/width.js',
-      'modifiers/container-query.js',
-    ],
     publicAssets: [],
-    publicEntrypoints: [
-      'components/container-query.js',
-      'helpers/aspect-ratio.js',
-      'helpers/cq-aspect-ratio.js',
-      'helpers/cq-height.js',
-      'helpers/cq-width.js',
-      'helpers/height.js',
-      'helpers/width.js',
-      'index.js',
-      'modifiers/container-query.js',
-    ],
   },
   projectRoot: {
     devDependencies: {

--- a/tests/steps/analyze-addon/blueprints.test.ts
+++ b/tests/steps/analyze-addon/blueprints.test.ts
@@ -29,9 +29,7 @@ test('steps | analyze-addon > blueprints', function () {
 
   assert.deepStrictEqual(analyzeAddon(options), {
     addon: {
-      appReexports: [],
       publicAssets: [],
-      publicEntrypoints: [],
     },
     projectRoot: {
       devDependencies: {

--- a/tests/steps/analyze-addon/edge-case-folders-are-missing.test.ts
+++ b/tests/steps/analyze-addon/edge-case-folders-are-missing.test.ts
@@ -13,9 +13,7 @@ test('steps | analyze-addon > edge case (folders are missing)', function () {
 
   assert.deepStrictEqual(analyzeAddon(options), {
     addon: {
-      appReexports: [],
       publicAssets: [],
-      publicEntrypoints: [],
     },
     projectRoot: {
       devDependencies: {

--- a/tests/steps/analyze-addon/public-assets.test.ts
+++ b/tests/steps/analyze-addon/public-assets.test.ts
@@ -26,12 +26,10 @@ test('steps | analyze-addon > public-assets', function () {
 
   assert.deepStrictEqual(analyzeAddon(options), {
     addon: {
-      appReexports: [],
       publicAssets: [
         'assets/documents/some-file.pdf',
         'assets/images/v1/some-file.svg',
       ],
-      publicEntrypoints: [],
     },
     projectRoot: {
       devDependencies: {

--- a/tests/steps/analyze-addon/test-support.test.ts
+++ b/tests/steps/analyze-addon/test-support.test.ts
@@ -20,12 +20,7 @@ test('steps | analyze-addon > test-support', function () {
 
   assert.deepStrictEqual(analyzeAddon(options), {
     addon: {
-      appReexports: [],
       publicAssets: [],
-      publicEntrypoints: [
-        'test-support/components/container-query.js',
-        'test-support/index.js',
-      ],
     },
     projectRoot: {
       devDependencies: {


### PR DESCRIPTION
## What changed?

I made a few changes to how the codemod updates the addon package.

- `babel.config.json`: Updated Babel dependencies
- `rollup.config.mjs`: Simplified `addon.publicEntrypoints()` and `addon.appReexports()` (the file pattern arrays are static; they are no longer derived in the `analyze-addon` step)
- `rollup.config.mjs`: Added `addon.gjs()` (i.e. allow writing `<template>`-tag components)
- `package.json`: Replaced `ember-cli-typescript` with `typescript`
- `tsconfig.json`: Extended `@tsconfig/ember`
