### PR TITLE
Downstreamed changes from @embroider/addon-blueprint@2.11.0

### DIFF
--- a/src/blueprints/ember-addon/__addonLocation__/babel.config.json
+++ b/src/blueprints/ember-addon/__addonLocation__/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
 <% } %>    "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/src/blueprints/ember-addon/__addonLocation__/unpublished-development-types/index.d.ts
+++ b/src/blueprints/ember-addon/__addonLocation__/unpublished-development-types/index.d.ts
@@ -2,6 +2,7 @@
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
 <% if (options.packages.addon.hasGlint) { %>
 import '@glint/environment-ember-loose';
+// import '@glint/environment-ember-template-imports';
 
 declare module '@glint/environment-ember-loose/registry' {
   // Remove this once entries have been added! 👇

--- a/src/steps/update-addon-package-json/update-dependencies.ts
+++ b/src/steps/update-addon-package-json/update-dependencies.ts
@@ -24,7 +24,7 @@ export function updateDependencies(
     dependencies.delete(packageName);
   });
 
-  const packagesToInstall = ['@embroider/addon-shim'];
+  const packagesToInstall = ['@embroider/addon-shim', 'decorator-transforms'];
 
   packagesToInstall.forEach((packageName) => {
     const version = getVersion(packageName, options);

--- a/src/steps/update-addon-package-json/update-dev-dependencies.ts
+++ b/src/steps/update-addon-package-json/update-dev-dependencies.ts
@@ -25,9 +25,6 @@ export function updateDevDependencies(
 
   const packagesToInstall = new Set([
     '@babel/core',
-    '@babel/plugin-proposal-decorators',
-    '@babel/plugin-transform-class-properties',
-    '@babel/plugin-transform-class-static-block',
     '@babel/runtime',
     '@embroider/addon-dev',
     '@rollup/plugin-babel',

--- a/src/steps/update-addon-tsconfig-json.ts
+++ b/src/steps/update-addon-tsconfig-json.ts
@@ -21,6 +21,7 @@ function setCompilerOptions(
   compilerOptions.set('allowImportingTsExtensions', true);
   compilerOptions.set('allowJs', true);
   compilerOptions.set('declarationDir', 'declarations');
+  compilerOptions.set('rootDir', './src');
 
   if (!packages.addon.hasGlint) {
     compilerOptions.set('declaration', true);

--- a/src/utils/blueprints/get-version.ts
+++ b/src/utils/blueprints/get-version.ts
@@ -4,9 +4,6 @@ import type { Options } from '../../types/index.js';
 
 const latestVersions = new Map([
   ['@babel/core', '7.23.2'],
-  ['@babel/plugin-proposal-decorators', '7.22.15'],
-  ['@babel/plugin-transform-class-properties', '7.22.5'],
-  ['@babel/plugin-transform-class-static-block', '7.22.11'],
   ['@babel/plugin-transform-typescript', '7.22.15'],
   ['@babel/runtime', '7.23.2'],
   ['@embroider/addon-dev', '4.1.1'],
@@ -16,6 +13,7 @@ const latestVersions = new Map([
   ['@tsconfig/ember', '3.0.2'],
   ['babel-plugin-ember-template-compilation', '2.2.1'],
   ['concurrently', '8.2.2'],
+  ['decorator-transforms', '1.0.1'],
   ['ember-auto-import', '2.6.3'],
   ['ember-cli-babel', '8.1.0'],
   ['ember-cli-htmlbars', '6.3.0'],

--- a/src/utils/blueprints/get-version.ts
+++ b/src/utils/blueprints/get-version.ts
@@ -3,23 +3,23 @@ import { decideVersion } from '@codemod-utils/blueprints';
 import type { Options } from '../../types/index.js';
 
 const latestVersions = new Map([
-  ['@babel/core', '7.23.2'],
-  ['@babel/plugin-transform-typescript', '7.22.15'],
-  ['@babel/runtime', '7.23.2'],
-  ['@embroider/addon-dev', '4.1.1'],
-  ['@embroider/addon-shim', '1.8.6'],
-  ['@embroider/test-setup', '3.0.2'],
+  ['@babel/core', '7.23.6'],
+  ['@babel/plugin-transform-typescript', '7.23.6'],
+  ['@babel/runtime', '7.23.6'],
+  ['@embroider/addon-dev', '4.1.3'],
+  ['@embroider/addon-shim', '1.8.7'],
+  ['@embroider/test-setup', '3.0.3'],
   ['@rollup/plugin-babel', '6.0.4'],
-  ['@tsconfig/ember', '3.0.2'],
+  ['@tsconfig/ember', '3.0.3'],
   ['babel-plugin-ember-template-compilation', '2.2.1'],
   ['concurrently', '8.2.2'],
   ['decorator-transforms', '1.0.1'],
-  ['ember-auto-import', '2.6.3'],
+  ['ember-auto-import', '2.7.1'],
   ['ember-cli-babel', '8.1.0'],
   ['ember-cli-htmlbars', '6.3.0'],
-  ['rollup', '4.3.0'],
+  ['rollup', '4.9.1'],
   ['rollup-plugin-copy', '3.5.0'],
-  ['typescript', '5.2.2'],
+  ['typescript', '5.3.3'],
 ]);
 
 export function getVersion(packageName: string, options: Options): string {

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -66,15 +66,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -66,9 +67,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations"
+    "declarationDir": "declarations",
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/unpublished-development-types/index.d.ts
@@ -2,6 +2,7 @@
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
 
 import '@glint/environment-ember-loose';
+// import '@glint/environment-ember-template-imports';
 
 declare module '@glint/environment-ember-loose/registry' {
   // Remove this once entries have been added! 👇

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -66,15 +66,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -66,9 +67,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations"
+    "declarationDir": "declarations",
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/ember-container-query-glint/output/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/ember-container-query-glint/output/ember-container-query/unpublished-development-types/index.d.ts
@@ -2,6 +2,7 @@
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
 
 import '@glint/environment-ember-loose';
+// import '@glint/environment-ember-template-imports';
 
 declare module '@glint/environment-ember-loose/registry' {
   // Remove this once entries have been added! 👇

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/babel.config.json
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -9,7 +8,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -61,9 +62,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",

--- a/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-javascript/output/ember-container-query/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -61,13 +61,13 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -66,15 +66,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -66,9 +67,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations"
+    "declarationDir": "declarations",
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/ember-container-query-scoped/output/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/ember-container-query-scoped/output/ember-container-query/unpublished-development-types/index.d.ts
@@ -2,6 +2,7 @@
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
 
 import '@glint/environment-ember-loose';
+// import '@glint/environment-ember-template-imports';
 
 declare module '@glint/environment-ember-loose/registry' {
   // Remove this once entries have been added! 👇

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -66,15 +66,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -66,9 +67,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/ember-container-query-typescript/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/ember-container-query-typescript/output/ember-container-query/tsconfig.json
@@ -6,7 +6,8 @@
     "declaration": true,
     "declarationDir": "declarations",
     "emitDeclarationOnly": true,
-    "noEmit": false
+    "noEmit": false,
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
@@ -32,19 +32,19 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
@@ -32,13 +32,11 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6"
+    "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/tsconfig.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/tsconfig.json
@@ -6,7 +6,8 @@
     "declaration": true,
     "declarationDir": "declarations",
     "emitDeclarationOnly": true,
-    "noEmit": false
+    "noEmit": false,
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/babel.config.json
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -9,7 +8,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
@@ -27,17 +27,17 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-javascript/output/new-v1-addon/package.json
@@ -27,13 +27,11 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6"
+    "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/babel.config.json
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -9,7 +8,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
@@ -27,17 +27,17 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-npm/output/new-v1-addon/package.json
@@ -27,13 +27,11 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6"
+    "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/babel.config.json
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -9,7 +8,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
@@ -27,17 +27,17 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0"
   },
   "peerDependencies": {

--- a/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-pnpm/output/new-v1-addon/package.json
@@ -27,13 +27,11 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6"
+    "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/babel.config.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
@@ -32,19 +32,19 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/package.json
@@ -32,13 +32,11 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6"
+    "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/tsconfig.json
+++ b/tests/fixtures/new-v1-addon-typescript/output/new-v1-addon/tsconfig.json
@@ -6,7 +6,8 @@
     "declaration": true,
     "declarationDir": "declarations",
     "emitDeclarationOnly": true,
-    "noEmit": false
+    "noEmit": false,
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/steps/create-files-from-blueprints/customizations/output/packages/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/customizations/output/packages/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/customizations/output/packages/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprints/customizations/output/packages/ember-container-query/unpublished-development-types/index.d.ts
@@ -2,6 +2,7 @@
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
 
 import '@glint/environment-ember-loose';
+// import '@glint/environment-ember-template-imports';
 
 declare module '@glint/environment-ember-loose/registry' {
   // Remove this once entries have been added! 👇

--- a/tests/fixtures/steps/create-files-from-blueprints/glint/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/glint/output/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/glint/output/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprints/glint/output/ember-container-query/unpublished-development-types/index.d.ts
@@ -2,6 +2,7 @@
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
 
 import '@glint/environment-ember-loose';
+// import '@glint/environment-ember-template-imports';
 
 declare module '@glint/environment-ember-loose/registry' {
   // Remove this once entries have been added! 👇

--- a/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/javascript/output/ember-container-query/babel.config.json
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -9,7 +8,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/npm/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/npm/output/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/pnpm/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/pnpm/output/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/scoped/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/scoped/output/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/steps/create-files-from-blueprints/scoped/output/ember-container-query/unpublished-development-types/index.d.ts
+++ b/tests/fixtures/steps/create-files-from-blueprints/scoped/output/ember-container-query/unpublished-development-types/index.d.ts
@@ -2,6 +2,7 @@
 // These will *not* be published as part of your addon, so be careful that your published code does not rely on them!
 
 import '@glint/environment-ember-loose';
+// import '@glint/environment-ember-template-imports';
 
 declare module '@glint/environment-ember-loose/registry' {
   // Remove this once entries have been added! 👇

--- a/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-container-query/babel.config.json
+++ b/tests/fixtures/steps/create-files-from-blueprints/typescript/output/ember-container-query/babel.config.json
@@ -9,7 +9,6 @@
       }
     ],
     "@embroider/addon-dev/template-colocation-plugin",
-    "@babel/plugin-transform-class-static-block",
     [
       "babel-plugin-ember-template-compilation",
       {
@@ -17,7 +16,13 @@
         "transforms": []
       }
     ],
-    ["@babel/plugin-proposal-decorators", { "version": "legacy" }],
-    "@babel/plugin-transform-class-properties"
+    [
+      "module:decorator-transforms",
+      {
+        "runtime": {
+          "import": "decorator-transforms/runtime"
+        }
+      }
+    ]
   ]
 }

--- a/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -66,15 +66,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -66,9 +67,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -66,15 +66,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/glint/output/ember-container-query/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -66,9 +67,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -61,9 +62,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.20.7",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",
     "@rollup/plugin-babel": "^6.0.4",

--- a/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/javascript/output/ember-container-query/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -61,13 +61,13 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0"
   },
   "engines": {

--- a/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -66,15 +66,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/public-assets/output/ember-container-query/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -66,9 +67,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -66,15 +66,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/scoped/output/ember-container-query/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -66,9 +67,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.6",
+    "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
@@ -66,15 +66,15 @@
     "ember-test-selectors": "^6.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/plugin-transform-typescript": "^7.22.15",
-    "@babel/runtime": "^7.23.2",
-    "@embroider/addon-dev": "^4.1.1",
+    "@babel/core": "^7.23.6",
+    "@babel/plugin-transform-typescript": "^7.23.6",
+    "@babel/runtime": "^7.23.6",
+    "@embroider/addon-dev": "^4.1.3",
     "@rollup/plugin-babel": "^6.0.4",
     "@tsconfig/ember": "^2.0.0",
     "babel-plugin-ember-template-compilation": "^2.2.1",
     "concurrently": "^7.6.0",
-    "rollup": "^4.3.0",
+    "rollup": "^4.9.1",
     "rollup-plugin-copy": "^3.5.0",
     "typescript": "^4.9.4"
   },

--- a/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/typescript/output/ember-container-query/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.8.6",
+    "decorator-transforms": "^1.0.1",
     "ember-element-helper": "^0.6.1",
     "ember-modifier": "^3.2.7",
     "ember-resize-observer-service": "^1.1.0",
@@ -66,9 +67,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.23.2",
-    "@babel/plugin-proposal-decorators": "^7.22.15",
-    "@babel/plugin-transform-class-properties": "^7.22.5",
-    "@babel/plugin-transform-class-static-block": "^7.22.11",
     "@babel/plugin-transform-typescript": "^7.22.15",
     "@babel/runtime": "^7.23.2",
     "@embroider/addon-dev": "^4.1.1",

--- a/tests/fixtures/steps/update-addon-tsconfig-json/customizations/output/packages/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/customizations/output/packages/ember-container-query/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations"
+    "declarationDir": "declarations",
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/steps/update-addon-tsconfig-json/glint/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/glint/output/ember-container-query/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations"
+    "declarationDir": "declarations",
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/steps/update-addon-tsconfig-json/scoped/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/scoped/output/ember-container-query/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "allowImportingTsExtensions": true,
     "allowJs": true,
-    "declarationDir": "declarations"
+    "declarationDir": "declarations",
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*",

--- a/tests/fixtures/steps/update-addon-tsconfig-json/typescript/output/ember-container-query/tsconfig.json
+++ b/tests/fixtures/steps/update-addon-tsconfig-json/typescript/output/ember-container-query/tsconfig.json
@@ -6,7 +6,8 @@
     "declaration": true,
     "declarationDir": "declarations",
     "emitDeclarationOnly": true,
-    "noEmit": false
+    "noEmit": false,
+    "rootDir": "./src"
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
## What changed?

- Replaced Babel plugins with [`decorator-transforms`](https://github.com/ef4/decorator-transforms)
- Updated TypeScript and Glint configurations for the addon package
- Updated `latestVersions`

I tested the changes on a couple of addons:

- https://github.com/ijlee2/ember-container-query/pull/217
- https://github.com/ijlee2/embroider-css-modules/pull/122
