### PR TITLE
Removed hardcoded locations for test-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In most cases, I recommend running the codemod without any arguments (i.e. allow
 By default, the package name decides where the addon package lives. Pass `--addon-location` to override the logic. This may be useful if you have a workspace with many addons.
 
 ```sh
-npx ember-codemod-v1-to-v2 --addon-location packages/ui/buttons
+npx ember-codemod-v1-to-v2 --addon-location packages/ui/button
 ```
 
 </details>
@@ -94,7 +94,7 @@ npx ember-codemod-v1-to-v2 --test-app-location docs-app
 By default, the test-app package is named `test-app`. Pass `--test-app-name` to override the logic. This may be useful if you have a workspace with many addons.
 
 ```sh
-npx ember-codemod-v1-to-v2 --test-app-name test-app-for-ui-buttons
+npx ember-codemod-v1-to-v2 --test-app-name test-app-for-ui-button
 ```
 
 </details>

--- a/src/steps/update-addon-package-json/update-scripts.ts
+++ b/src/steps/update-addon-package-json/update-scripts.ts
@@ -6,7 +6,7 @@ export function updateScripts(
   packageJson: PackageJson,
   options: Options,
 ): void {
-  const { packages } = options;
+  const { locations, packages } = options;
 
   const scripts = convertToMap(packageJson['scripts']);
 
@@ -40,7 +40,7 @@ export function updateScripts(
 
     scripts.set(
       'test',
-      "echo 'A v2 addon does not have tests, run tests in test-app'",
+      `echo 'A v2 addon does not have tests, run tests in ${locations.testApp}'`,
     );
   } else {
     scripts.set('build', 'rollup --config');
@@ -48,7 +48,7 @@ export function updateScripts(
     scripts.set('start', 'rollup --config --watch');
     scripts.set(
       'test',
-      "echo 'A v2 addon does not have tests, run tests in test-app'",
+      `echo 'A v2 addon does not have tests, run tests in ${locations.testApp}'`,
     );
   }
 

--- a/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/ember-container-query-customizations/output/packages/ember-container-query/package.json
@@ -43,7 +43,7 @@
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
     "start:types": "glint --declaration --watch",
-    "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
+    "test": "echo 'A v2 addon does not have tests, run tests in demo-app'",
     "test:ember": "ember test",
     "test:ember-compatibility": "./node_modules/.bin/ember try:one"
   },

--- a/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
+++ b/tests/fixtures/new-v1-addon-customizations/output/packages/new-v1-addon/package.json
@@ -27,7 +27,7 @@
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
     "start:types": "tsc --watch",
-    "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
+    "test": "echo 'A v2 addon does not have tests, run tests in demo-app'",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each"
   },

--- a/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
+++ b/tests/fixtures/steps/update-addon-package-json/customizations/output/packages/ember-container-query/package.json
@@ -43,7 +43,7 @@
     "start": "concurrently \"npm:start:*\" --names \"start:\"",
     "start:js": "rollup --config --watch --no-watch.clearScreen",
     "start:types": "glint --declaration --watch",
-    "test": "echo 'A v2 addon does not have tests, run tests in test-app'",
+    "test": "echo 'A v2 addon does not have tests, run tests in demo-app'",
     "test:ember": "ember test",
     "test:ember-compatibility": "./node_modules/.bin/ember try:one"
   },


### PR DESCRIPTION
## Description

When an end-developer passes `--test-app-location`, the `test` script in the addon package incorrectly showed `test-app` as the location of the test-app.
