### PR TITLE
Allowed pnpm to be the default manager, if unable to be determined

### DIFF
--- a/src/steps/create-options.ts
+++ b/src/steps/create-options.ts
@@ -52,9 +52,9 @@ function analyzePackageManager(codemodOptions: CodemodOptions): PackageManager {
   });
 
   if (filePaths.length !== 1) {
-    console.warn('WARNING: Package manager is unknown. Yarn will be assumed.');
+    console.warn('WARNING: Package manager is unknown. pnpm will be assumed.');
 
-    return 'yarn';
+    return 'pnpm';
   }
 
   const lockfile = filePaths[0] as keyof typeof mapping;


### PR DESCRIPTION
## Description

With v1 addons, `yarn` and `npm` were popular choices for package manager. With v2 addons, `pnpm` is preferred.
