### PR TITLE
Dropped Node v18 support

### DIFF
--- a/.changeset/plain-ideas-matter.md
+++ b/.changeset/plain-ideas-matter.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-v1-to-v2": major
+---
+
+Dropped Node v18 support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 20
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ You can also look at another codemod called [`ember-addon-migrator`](https://git
 
 ## Compatibility
 
-- Node.js v18 or above
+- Node.js v20 or above
 
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ijlee2-frontend-configs/prettier": "^0.2.3",
     "@ijlee2-frontend-configs/typescript": "^0.4.0",
     "@sondr3/minitest": "^0.1.2",
-    "@types/node": "^18.19.82",
+    "@types/node": "^20.17.27",
     "@types/yargs": "^17.0.33",
     "concurrently": "^9.1.2",
     "eslint": "^9.23.0",
@@ -62,7 +62,7 @@
   },
   "packageManager": "pnpm@9.15.9",
   "engines": {
-    "node": "18.* || >= 20"
+    "node": "20.* || >= 22"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^0.1.2
         version: 0.1.2
       '@types/node':
-        specifier: ^18.19.82
-        version: 18.19.82
+        specifier: ^20.17.27
+        version: 20.17.27
       '@types/yargs':
         specifier: ^17.0.33
         version: 17.0.33
@@ -423,8 +423,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@18.19.82':
-    resolution: {integrity: sha512-s6RBC3H0JGG5Xm2IOP2R0KKNZL2s46UGZZ1r21EF3+qL377EwJ+Bnf9PMatFnYtmYMNnzVLodD6EN7FZw0Vbxg==}
+  '@types/node@20.17.27':
+    resolution: {integrity: sha512-U58sbKhDrthHlxHRJw7ZLiLDZGmAUOZUbpw0S6nL27sYUdhvgBLCRu/keSd6qcTsfArd1sRFCCBxzWATGr/0UA==}
 
   '@types/rimraf@3.0.2':
     resolution: {integrity: sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==}
@@ -1909,8 +1909,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -2491,12 +2491,12 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 18.19.82
+      '@types/node': 20.17.27
 
   '@types/glob@8.1.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 18.19.82
+      '@types/node': 20.17.27
 
   '@types/json-schema@7.0.15': {}
 
@@ -2509,14 +2509,14 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@18.19.82':
+  '@types/node@20.17.27':
     dependencies:
-      undici-types: 5.26.5
+      undici-types: 6.19.8
 
   '@types/rimraf@3.0.2':
     dependencies:
       '@types/glob': 8.1.0
-      '@types/node': 18.19.82
+      '@types/node': 20.17.27
 
   '@types/semver@7.5.8': {}
 
@@ -4270,7 +4270,7 @@ snapshots:
       which-boxed-primitive: 1.1.1
     optional: true
 
-  undici-types@5.26.5: {}
+  undici-types@6.19.8: {}
 
   universalify@0.1.2: {}
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@ijlee2-frontend-configs/typescript/node18",
+  "extends": "@ijlee2-frontend-configs/typescript/node20",
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@ijlee2-frontend-configs/typescript/node18",
+  "extends": "@ijlee2-frontend-configs/typescript/node20",
   "compilerOptions": {
     "declaration": false,
     "outDir": "dist-for-testing"


### PR DESCRIPTION
## Background

Maintenance support for Node v18 ends on April 30, 2025.
